### PR TITLE
fix(table): remove unused CSS global style for sort indicator

### DIFF
--- a/packages/baukasten/src/components/Table/Table.css.ts
+++ b/packages/baukasten/src/components/Table/Table.css.ts
@@ -408,11 +408,4 @@ export const sortIndicator = recipe({
     },
 });
 
-/**
- * Sort indicator content based on direction
- */
-globalStyle(`${sortIndicator.classNames.base}::before`, {
-    content: '▲',
-});
-
 // Override for desc direction - we'll handle this with dynamic content in the component


### PR DESCRIPTION
What it does:

Removes the global style that set default sort indicator content via CSS `::before` pseudo-element. This styling is already handled dynamically in the component.

<img width="1114" height="214" alt="image" src="https://github.com/user-attachments/assets/7bc7635f-d943-4eb5-9c97-ac96f1f6f696" />
