### PR TITLE
refactor(css): replace hardcoded rgba values with design tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Baukasten is a VSCode webview UI toolkit built with React 19, TypeScript, vanilla-extract, and designed to match VSCode's native look and feel. This is a monorepo managed with npm workspaces.
 
-**Note**: The project is currently migrating from styled-components to vanilla-extract. Some components may still use styled-components during the transition period.
-
 ## Monorepo Structure
 
 ```
@@ -15,10 +13,9 @@ baukasten/
 ├── packages/
 │   ├── baukasten/           # Main UI component library (baukasten)
 │   ├── web-wrapper/         # VSCode theme wrapper for browser demos
+│   ├── website/             # Documentation website
 │   └── examples/
-│       ├── web-example/     # Web application example
-│       ├── table-example/   # Table component demo
-│       └── vscode/          # VSCode extension example
+│       └── web-example/     # Web application example
 ```
 
 ## Common Commands
@@ -39,12 +36,6 @@ npm run storybook
 # Run web example
 npm run example:web
 # Runs at http://localhost:3000
-
-# Run table example
-npm run example:table
-
-# Watch VSCode extension example (then press F5 in VSCode)
-npm run example:vscode
 ```
 
 ### Building
@@ -114,16 +105,13 @@ ComponentName/
 └── index.ts                  # Exports
 ```
 
-**For new components** (using vanilla-extract):
+**For components** (using vanilla-extract):
 1. Use semantic tokens from the design system via CSS variables
 2. Export TypeScript types for props
 3. Include comprehensive Storybook stories
 4. Use `recipe` API for variant-based styling
 5. Use `style` API for base styles
 6. Use `styleVariants` for simple variant maps
-
-**For legacy components** (still using styled-components):
-1. Follow the naming convention: `$propName` for transient props (until migrated)
 
 ### Theming System
 
@@ -167,14 +155,62 @@ Reference: `packages/baukasten/src/components/Button/Button.stories.tsx`
 ## Available Components
 
 Current components (exported from `baukasten`):
+
+**Form Controls:**
 - **Button** - Versatile button with variants (primary, secondary, ghost, outline) and sizes
+- **ButtonGroup** - Group of related buttons
 - **Input** - Text input with label and error state support
+- **TextArea** - Multi-line text input
+- **Select** - Dropdown selection component
+- **Checkbox** - Checkbox with label support
+- **Radio** - Radio button and RadioGroup components
+- **Slider** - Range slider input
+- **FileUpload** - File upload component with drag & drop
+
+**Form Helpers:**
 - **Label** - Form label component
+- **FieldLabel** - Field label with optional required indicator
+- **FormGroup** - Group form elements with consistent spacing
+- **FormHelper** - Helper text for form fields
+
+**Typography:**
+- **Heading** - h1-h6 headings with semantic sizing
+- **Text** - Inline text with size and weight variants
+- **Paragraph** - Block text element
+- **Code** - Inline and block code display
+- **Link** - Anchor links with variants
+- **Image** - Responsive images with loading states and captions
+
+**Data Display:**
 - **Badge** - Status indicator component
-- **Icon** - VSCode Codicons integration
-- **Typography** - Heading, Text, Paragraph, Code, Link, Image
 - **Table** - Basic table components with sorting and variants
 - **DataTable** - Advanced data table with virtualization, sorting, filtering
+- **Avatar** - User avatar with image/initials fallback
+
+**Navigation:**
+- **Tabs** - Tabbed navigation component
+- **Breadcrumbs** - Breadcrumb navigation
+- **Menu** - Dropdown menu component
+- **ContextMenu** - Right-click context menu
+- **Pagination** - Page navigation controls
+
+**Feedback:**
+- **Alert** - Alert messages with variants (info, success, warning, danger)
+- **Modal** - Modal dialog component
+- **Tooltip** - Hover tooltips
+- **Spinner** - Loading spinner
+- **ProgressBar** - Progress indicator with variants
+
+**Layout:**
+- **Divider** - Horizontal/vertical divider
+- **SplitPane** - Resizable split pane layout
+- **Accordion** - Collapsible content panels
+- **Dropdown** - Generic dropdown container
+
+**Specialized:**
+- **Icon** - VSCode Codicons integration
+- **StatusBar** - VSCode-style status bar
+- **Hero** - Hero section component
 
 ## Key Technical Details
 
@@ -204,7 +240,6 @@ Main package (`baukasten`) exports:
    - Export from `packages/baukasten/src/index.ts`
 3. **Test in examples**:
    - Web example for browser testing
-   - VSCode example for extension integration
 4. **Build**: `npm run build` before committing
 
 ## Important Files
@@ -219,7 +254,6 @@ Main package (`baukasten`) exports:
 
 - View in Storybook: `npm run storybook`
 - Test in web: `npm run example:web`
-- Test in VSCode: `npm run example:vscode` then F5
 - Use .vscode launch configurations for debugging
 
 ## Notes
@@ -556,17 +590,3 @@ export const Button: React.FC<ButtonProps> = ({
    });
    ```
 
-### Migration Checklist
-
-When migrating a component from styled-components to vanilla-extract:
-
-- [ ] Create `ComponentName.css.ts` file
-- [ ] Convert `styled.*` to `style()` or `recipe()`
-- [ ] Replace prop interpolation with `recipe` variants
-- [ ] Remove transient props (`$propName`) - use recipe variants instead
-- [ ] Update component imports
-- [ ] Use `className` instead of styled component wrapper
-- [ ] Extract variant types with `RecipeVariants`
-- [ ] Test all variant combinations in Storybook
-- [ ] Verify design tokens are used (no hardcoded values)
-- [ ] Remove styled-components imports after migration complete

--- a/README.md
+++ b/README.md
@@ -45,14 +45,10 @@ baukasten/
 This project includes pre-configured VSCode launch configurations. Simply:
 
 1. Open the project in VSCode
-2. Press **F5** to launch the VSCode extension example, or
-3. Use the **Run and Debug** panel to select:
-   - **Launch VSCode Extension Example**
+2. Use the **Run and Debug** panel to select:
    - **Attach to Web Example (Chrome)**
    - **Attach to Storybook (Chrome)**
    - **Launch All Examples** (runs multiple at once)
-
-See [.vscode/README.md](.vscode/README.md) for detailed instructions.
 
 #### Manual Commands:
 

--- a/package.json
+++ b/package.json
@@ -11,16 +11,13 @@
     "build:web-wrapper": "npm run build --workspace=packages/web-wrapper",
     "build:baukasten": "npm run build --workspace=packages/baukasten",
     "build:website": "npm run build --workspace=packages/website",
-    "build:vscode": "npm run build --workspace=packages/examples/vscode",
     "dev": "npm run dev --workspace=packages/baukasten",
     "storybook": "npm run storybook --workspace=packages/baukasten",
     "build-storybook": "npm run build:web-wrapper && cd packages/baukasten && NODE_PATH=./node_modules npm run build-storybook",
     "website": "npm run dev --workspace=packages/website",
     "website:build": "npm run build --workspace=packages/website",
     "website:start": "npm run start --workspace=packages/website",
-    "example:web": "npm run dev --workspace=packages/examples/web-example",
-    "example:table": "npm run dev --workspace=packages/examples/table-example",
-    "example:vscode": "npm run watch --workspace=packages/examples/vscode"
+    "example:web": "npm run dev --workspace=packages/examples/web-example"
   },
   "devDependencies": {
     "typescript": "^5.3.3"

--- a/packages/baukasten/src/components/Modal/Modal.css.ts
+++ b/packages/baukasten/src/components/Modal/Modal.css.ts
@@ -22,11 +22,11 @@ export const backdrop = recipe({
   variants: {
     variant: {
       solid: {
-        backgroundColor: 'rgba(0, 0, 0, 0.5)', // Standard semi-transparent black
+        backgroundColor: 'var(--bk-color-backdrop)',
         backdropFilter: 'none',
       },
       blur: {
-        backgroundColor: 'rgba(0, 0, 0, 0.3)', // Lighter for blur effect
+        backgroundColor: 'var(--bk-color-backdrop-blur)',
         backdropFilter: 'blur(var(--bk-spacing-1))', // 4px
       },
       transparent: {

--- a/packages/baukasten/src/components/ProgressBar/ProgressBar.css.ts
+++ b/packages/baukasten/src/components/ProgressBar/ProgressBar.css.ts
@@ -94,7 +94,7 @@ export const progressBarFill = recipe({
     },
     striped: {
       true: {
-        backgroundImage: 'linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent)', // Semi-transparent white stripes
+        backgroundImage: 'linear-gradient(45deg, var(--bk-color-stripe-overlay) 25%, transparent 25%, transparent 50%, var(--bk-color-stripe-overlay) 50%, var(--bk-color-stripe-overlay) 75%, transparent 75%, transparent)',
         backgroundSize: `${STRIPE_SIZE} ${STRIPE_SIZE}`,
       },
       false: {},

--- a/packages/baukasten/src/components/Typography/Image.css.ts
+++ b/packages/baukasten/src/components/Typography/Image.css.ts
@@ -50,7 +50,7 @@ export const imageWrapper = recipe({
             left: 0,
             right: 0,
             height: '50%', // Cover bottom half for caption readability
-            background: 'linear-gradient(to top, rgba(0, 0, 0, 0.7), transparent)', // Dark to transparent gradient
+            background: 'linear-gradient(to top, var(--bk-color-overlay-gradient-start), transparent)',
             pointerEvents: 'none',
             borderRadius: 'inherit',
           },
@@ -204,8 +204,8 @@ export const caption = recipe({
         left: 0,
         right: 0,
         padding: 'var(--bk-spacing-3)',
-        color: 'white',
-        zIndex: 1, // Above gradient overlay
+        color: 'var(--bk-color-overlay-foreground)',
+        zIndex: 'var(--bk-z-index-overlay-content)',
       },
     },
 

--- a/packages/baukasten/src/components/Typography/Link.tsx
+++ b/packages/baukasten/src/components/Typography/Link.tsx
@@ -64,11 +64,6 @@ export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement>
  *
  * // Large link
  * <Link size="lg" href="/home">Home</Link>
- *
- * // As a button (no href)
- * <Link as="button" onClick={() => console.log('clicked')}>
- *   Click me
- * </Link>
  * ```
  */
 export const Link: React.FC<LinkProps> = ({

--- a/packages/baukasten/src/styles/colors.ts
+++ b/packages/baukasten/src/styles/colors.ts
@@ -72,6 +72,17 @@ export const colorTokens = `
     --bk-color-overlay: rgba(0, 0, 0, 0.5);
     --bk-color-overlay-light: rgba(0, 0, 0, 0.1);
 
+    /* Backdrop colors (for modal/dialog overlays) */
+    --bk-color-backdrop: rgba(0, 0, 0, 0.5);
+    --bk-color-backdrop-blur: rgba(0, 0, 0, 0.3);
+
+    /* Image overlay gradient */
+    --bk-color-overlay-gradient-start: rgba(0, 0, 0, 0.7);
+    --bk-color-overlay-foreground: #ffffff;
+
+    /* Progress bar stripe overlay */
+    --bk-color-stripe-overlay: rgba(255, 255, 255, 0.15);
+
     /* ========================================================================
      * INTERACTIVE STATES
      * Hover, active, focus, and disabled states
@@ -228,6 +239,14 @@ export type ColorToken =
   | "border"
   | "border-focus"
   | "border-hover"
+  // Overlays/Backdrops
+  | "overlay"
+  | "overlay-light"
+  | "backdrop"
+  | "backdrop-blur"
+  | "overlay-gradient-start"
+  | "overlay-foreground"
+  | "stripe-overlay"
   // Interactive
   | "hover"
   | "active"

--- a/packages/baukasten/src/styles/effects.ts
+++ b/packages/baukasten/src/styles/effects.ts
@@ -50,6 +50,7 @@ export const effectsTokens = `
      * Z-INDEX SCALE
      * ======================================================================== */
     --bk-z-index-base: 0;
+    --bk-z-index-overlay-content: 1;  /* Content layered above overlay backgrounds (e.g., image captions) */
     --bk-z-index-sticky: 1020;
     --bk-z-index-fixed: 1030;
     --bk-z-index-modal-backdrop: 1040;
@@ -103,7 +104,7 @@ export type Transition = 'fast' | 'base' | 'slow';
 export type TransitionProperty = 'colors' | 'all' | 'transform' | 'opacity';
 
 export type ZIndex =
-  | 'base' | 'dropdown' | 'sticky' | 'fixed'
+  | 'base' | 'overlay-content' | 'dropdown' | 'sticky' | 'fixed'
   | 'modal-backdrop' | 'modal' | 'popover' | 'context-menu' | 'tooltip' | 'notification';
 
 export type Opacity =


### PR DESCRIPTION

## What it does:
- Add new color tokens for backdrops, overlays, and stripe patterns
- Add z-index token for overlay content layering
- Update Modal, ProgressBar, and Image components to use tokens
- Update CLAUDE.md to reflect current project structure
- Remove references to deprecated examples (vscode, table-example)
- Remove styled-components migration notes (migration complete)
- Expand ColorToken and ZIndex types with new values



<!-- Feel free to add a screenshot if applicable -->


<!-- Pick one, to help guide reviewers -->
My PR is:
- [x] Low risk (docs, tests, minor fixes)
- [ ] Medium risk (above average work, refactors)
- [ ] High risk (infra, critical changes)

