### PR TITLE
feat(portal): add PortalProvider for multi-window support in Eclipse …

### DIFF
--- a/packages/baukasten/README.md
+++ b/packages/baukasten/README.md
@@ -91,6 +91,78 @@ import 'baukasten-ui/dist/baukasten-theia.css';  // For Eclipse Theia
 import 'baukasten-ui/dist/baukasten-web.css';    // For standalone web apps
 ```
 
+## Usage in Eclipse Theia
+
+### Basic Setup
+
+Eclipse Theia applications use the Theia-specific CSS file:
+
+```tsx
+import { Button, Input, Badge } from 'baukasten-ui';
+import 'baukasten-ui/dist/baukasten-base.css';
+import 'baukasten-ui/dist/baukasten-theia.css';
+
+function App() {
+  return (
+    <div>
+      <Button variant="primary">Click me</Button>
+      <Input label="Username" placeholder="Enter username" />
+    </div>
+  );
+}
+```
+
+### Multi-Window Support (Secondary Windows)
+
+When using Baukasten in Theia secondary/popup windows, portal-based components (Select, Dropdown, Tooltip, etc.) need a `PortalProvider` to ensure dropdowns render in the correct window:
+
+```tsx
+import { useRef, useState, useEffect } from 'react';
+import { PortalProvider, Select, Dropdown, Button } from 'baukasten-ui';
+import 'baukasten-ui/dist/baukasten-base.css';
+import 'baukasten-ui/dist/baukasten-theia.css';
+
+function SecondaryWindowContent() {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [ready, setReady] = useState(false);
+  
+  // Wait for ref to be available
+  useEffect(() => setReady(true), []);
+  
+  return (
+    <div ref={rootRef} style={{ height: '100%' }}>
+      {ready && (
+        <PortalProvider root={rootRef.current}>
+          {/* All portal content will now render in this window */}
+          <Select
+            options={[
+              { value: '1', label: 'Option 1' },
+              { value: '2', label: 'Option 2' },
+            ]}
+            placeholder="Select an option"
+          />
+          
+          <Dropdown trigger={<Button>Open Menu</Button>}>
+            <div>Menu content</div>
+          </Dropdown>
+        </PortalProvider>
+      )}
+    </div>
+  );
+}
+```
+
+**Why is this needed?**
+
+By default, portal-based components render floating content (dropdowns, tooltips) to the main window's `document.body`. In Theia's secondary windows, this causes the content to appear on the wrong window. The `PortalProvider` redirects portal content to the correct window.
+
+**Components that use portals:**
+- `Select` - dropdown options
+- `Dropdown` - dropdown content
+- `Tooltip` - tooltip popups
+- `ContextMenu` - right-click menus
+- `ButtonGroup.Dropdown` - split button menus
+
 ## Components
 
 ### Button

--- a/packages/baukasten/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/baukasten/src/components/ButtonGroup/ButtonGroup.tsx
@@ -18,6 +18,7 @@ import {
 import { type Size } from '../../styles';
 import { Button, type ButtonVariant } from '../Button';
 import { Icon } from '../Icon';
+import { usePortalRoot } from '../../context';
 import {
   buttonGroup,
   dropdownTriggerWrapper,
@@ -280,6 +281,9 @@ const ButtonGroupDropdown: React.FC<ButtonGroupDropdownProps> = ({
     }
   }, [closeOnClick, isControlled, onOpenChange]);
 
+  // Get portal root from context (for multi-window support)
+  const portalRoot = usePortalRoot();
+
   return (
     <>
       <div
@@ -302,7 +306,7 @@ const ButtonGroupDropdown: React.FC<ButtonGroupDropdownProps> = ({
 
       {/* Portal with transition support for exit animations */}
       {isMounted && (
-        <FloatingPortal>
+        <FloatingPortal root={portalRoot}>
           <FloatingFocusManager context={context} modal={false}>
             <div
               ref={refs.setFloating}

--- a/packages/baukasten/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/baukasten/src/components/ContextMenu/ContextMenu.tsx
@@ -13,6 +13,7 @@ import {
 } from '@floating-ui/react';
 import { Menu } from '../Menu';
 import type { MenuProps } from '../Menu';
+import { usePortalRoot } from '../../context';
 import { menuWrapper, styledMenu, triggerWrapper } from './ContextMenu.css';
 
 /**
@@ -169,6 +170,9 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
     setIsOpen(false);
   }, []);
 
+  // Get portal root from context (for multi-window support)
+  const portalRoot = usePortalRoot();
+
   return (
     <>
       <div className={triggerWrapper} onContextMenu={handleContextMenu}>
@@ -177,7 +181,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
 
       {/* Portal with transition support for exit animations */}
       {isMounted && (
-        <FloatingPortal>
+        <FloatingPortal root={portalRoot}>
           <FloatingFocusManager context={context} modal={false}>
             <div
               ref={refs.setFloating}

--- a/packages/baukasten/src/components/Dropdown/Dropdown.tsx
+++ b/packages/baukasten/src/components/Dropdown/Dropdown.tsx
@@ -15,6 +15,7 @@ import {
   FloatingFocusManager,
   type Placement,
 } from '@floating-ui/react';
+import { usePortalRoot } from '../../context';
 import { dropdownWrapper, triggerWrapper, portalContent } from './Dropdown.css';
 
 /**
@@ -238,6 +239,9 @@ export const Dropdown: React.FC<DropdownProps> = ({
     }
   }, [closeOnClick, isControlled, onOpenChange]);
 
+  // Get portal root from context (for multi-window support)
+  const portalRoot = usePortalRoot();
+
   return (
     <>
       <div
@@ -252,7 +256,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
 
       {/* Portal with transition support for exit animations */}
       {isMounted && (
-        <FloatingPortal>
+        <FloatingPortal root={portalRoot}>
           <FloatingFocusManager context={context} modal={modal}>
             <div
               ref={refs.setFloating}

--- a/packages/baukasten/src/components/Select/Select.tsx
+++ b/packages/baukasten/src/components/Select/Select.tsx
@@ -16,6 +16,7 @@ import {
 } from '@floating-ui/react';
 import { type Size } from '../../styles';
 import { Icon } from '../Icon';
+import { usePortalRoot } from '../../context';
 import * as styles from './Select.css';
 
 // Floating UI numeric values (required by Floating UI API)
@@ -535,6 +536,9 @@ export function Select<T = string>({
 
   // Floating UI handles click-outside and position updates automatically via autoUpdate and useDismiss
 
+  // Get portal root from context (for multi-window support)
+  const portalRoot = usePortalRoot();
+
   const containerClassName = className
     ? `${styles.selectContainer({ fullWidth })} ${className}`
     : styles.selectContainer({ fullWidth });
@@ -574,7 +578,7 @@ export function Select<T = string>({
       </button>
 
       {isMounted && (
-        <FloatingPortal>
+        <FloatingPortal root={portalRoot}>
           <div
             ref={refs.setFloating}
             className={`${styles.floatingWrapper}${dropdownClassName ? ` ${dropdownClassName}` : ''}`}

--- a/packages/baukasten/src/components/Tooltip/Tooltip.tsx
+++ b/packages/baukasten/src/components/Tooltip/Tooltip.tsx
@@ -16,6 +16,7 @@ import {
   type Placement,
 } from '@floating-ui/react';
 import React, { useRef, useState } from 'react';
+import { usePortalRoot } from '../../context';
 import * as styles from './Tooltip.css';
 
 // Floating UI numeric values (required by Floating UI API)
@@ -207,6 +208,8 @@ export const Tooltip: React.FC<TooltipProps> = ({
     error: 'var(--bk-color-danger)',
     info: 'var(--bk-color-info)',
   }[variant];
+  // Get portal root from context (for multi-window support)
+  const portalRoot = usePortalRoot();
 
   return (
     <>
@@ -219,7 +222,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
       </div>
 
       {isMounted && (
-        <FloatingPortal>
+        <FloatingPortal root={portalRoot}>
           <div
             ref={refs.setFloating}
             style={{

--- a/packages/baukasten/src/context/PortalProvider.tsx
+++ b/packages/baukasten/src/context/PortalProvider.tsx
@@ -1,0 +1,159 @@
+import { createContext, useContext, type ReactNode } from 'react';
+
+/**
+ * Context for configuring the portal root element
+ * 
+ * This is essential for multi-window applications (like Eclipse Theia)
+ * where components rendered in secondary windows need their portals
+ * to target the correct window's DOM rather than the main window.
+ */
+export interface PortalContextValue {
+    /**
+     * The root element for rendering portals
+     * When null, portals will use their default behavior (document.body)
+     */
+    root: HTMLElement | null;
+}
+
+const PortalContext = createContext<PortalContextValue>({ root: null });
+
+/**
+ * Props for the PortalProvider component
+ */
+export interface PortalProviderProps {
+    /**
+     * The root element where portals should be rendered
+     * 
+     * In multi-window applications (like Eclipse Theia), this should be
+     * an element in the current window to ensure dropdowns, tooltips,
+     * and other portaled content appear in the correct window.
+     * 
+     * @example
+     * ```tsx
+     * // For Theia secondary windows, use a ref to an element in that window
+     * const containerRef = useRef<HTMLDivElement>(null);
+     * 
+     * return (
+     *   <div ref={containerRef}>
+     *     <PortalProvider root={containerRef.current}>
+     *       <YourApp />
+     *     </PortalProvider>
+     *   </div>
+     * );
+     * ```
+     * 
+     * @example
+     * ```tsx
+     * // Or use the window's document body directly
+     * <PortalProvider root={window.document.body}>
+     *   <YourApp />
+     * </PortalProvider>
+     * ```
+     */
+    root: HTMLElement | null;
+
+    /**
+     * The content to render within this portal context
+     */
+    children: ReactNode;
+}
+
+/**
+ * PortalProvider component
+ * 
+ * Provides a context for specifying where portal content (dropdowns, tooltips,
+ * modals, etc.) should be rendered. This is critical for multi-window applications
+ * like Eclipse Theia where content in secondary windows needs portals to render
+ * in the same window.
+ * 
+ * **Problem solved:**
+ * Without PortalProvider, portal-based components (Select, Dropdown, Tooltip, etc.)
+ * render their floating content to the main window's document.body. In multi-window
+ * scenarios, this causes dropdowns opened in a secondary window to appear in the
+ * main window instead.
+ * 
+ * **Usage:**
+ * 
+ * @example
+ * ```tsx
+ * // Basic usage - wrap your app at the root level
+ * function App() {
+ *   const containerRef = useRef<HTMLDivElement>(null);
+ *   const [mounted, setMounted] = useState(false);
+ *   
+ *   useEffect(() => setMounted(true), []);
+ *   
+ *   return (
+ *     <div ref={containerRef} id="app-root">
+ *       {mounted && (
+ *         <PortalProvider root={containerRef.current}>
+ *           <Select options={options} />
+ *           <Tooltip content="Hello">
+ *             <Button>Hover me</Button>
+ *           </Tooltip>
+ *         </PortalProvider>
+ *       )}
+ *     </div>
+ *   );
+ * }
+ * ```
+ * 
+ * @example
+ * ```tsx
+ * // Theia secondary window example
+ * function SecondaryWindowContent() {
+ *   // Use a ref to ensure portals render in this window
+ *   const rootRef = useRef<HTMLDivElement>(null);
+ *   const [ready, setReady] = useState(false);
+ *   
+ *   useEffect(() => setReady(true), []);
+ *   
+ *   return (
+ *     <div ref={rootRef} className="secondary-window-container">
+ *       {ready && (
+ *         <PortalProvider root={rootRef.current}>
+ *           <MyComponentWithDropdowns />
+ *         </PortalProvider>
+ *       )}
+ *     </div>
+ *   );
+ * }
+ * ```
+ * 
+ * **Note:** If PortalProvider is not used, components will fall back to their
+ * default portal behavior (rendering to document.body), which works fine for
+ * single-window applications.
+ */
+export function PortalProvider({ root, children }: PortalProviderProps) {
+    return (
+        <PortalContext.Provider value={{ root }}>
+            {children}
+        </PortalContext.Provider>
+    );
+}
+
+/**
+ * Hook to access the portal root element from context
+ * 
+ * Returns null if no PortalProvider is present, which signals components
+ * to use their default portal behavior.
+ * 
+ * @returns The portal root element or null
+ * 
+ * @example
+ * ```tsx
+ * function MyPortalComponent() {
+ *   const portalRoot = usePortalRoot();
+ *   
+ *   return (
+ *     <FloatingPortal root={portalRoot}>
+ *       <div>Portal content</div>
+ *     </FloatingPortal>
+ *   );
+ * }
+ * ```
+ */
+export function usePortalRoot(): HTMLElement | null {
+    const context = useContext(PortalContext);
+    return context.root;
+}

--- a/packages/baukasten/src/context/index.ts
+++ b/packages/baukasten/src/context/index.ts
@@ -1,0 +1,2 @@
+export { PortalProvider, usePortalRoot } from './PortalProvider';
+export type { PortalProviderProps, PortalContextValue } from './PortalProvider';

--- a/packages/baukasten/src/index.ts
+++ b/packages/baukasten/src/index.ts
@@ -204,6 +204,10 @@ export type {
   StatusBarItemVariant,
 } from "./components/StatusBar";
 
+// Context providers
+export { PortalProvider, usePortalRoot } from "./context";
+export type { PortalProviderProps, PortalContextValue } from "./context";
+
 // Style utilities
 export * from "./styles";
 

--- a/packages/website/src/app/guides/theia/page.tsx
+++ b/packages/website/src/app/guides/theia/page.tsx
@@ -1,0 +1,296 @@
+'use client';
+
+import PageLayout from '@/components/PageLayout';
+import CodeBlock from '@/components/CodeBlock';
+import Link from 'next/link';
+import { Heading, Alert, Icon, Divider } from 'baukasten-ui';
+
+const Section = ({ children }: { children: React.ReactNode }) => (
+    <section style={{ marginBottom: 'var(--bk-spacing-12)' }}>{children}</section>
+);
+
+const Paragraph = ({ children }: { children: React.ReactNode }) => (
+    <p style={{
+        fontSize: 'var(--bk-font-size-md)',
+        color: 'var(--bk-color-text-secondary)',
+        margin: '0 0 var(--bk-spacing-4) 0',
+        lineHeight: 'var(--bk-line-height-relaxed)',
+    }}>{children}</p>
+);
+
+export default function TheiaGuidePage() {
+    return (
+        <PageLayout
+            title="Usage in Eclipse Theia"
+            description="Learn how to use Baukasten components in Eclipse Theia applications, including multi-window support."
+        >
+            <Alert variant="info" icon={<Icon name="window" />} style={{ marginBottom: 'var(--bk-spacing-8)' }}>
+                Baukasten supports Eclipse Theia applications with special handling for multi-window scenarios where secondary/popup windows are common.
+            </Alert>
+
+            <Section>
+                <Heading level={2}>Installation</Heading>
+                <Paragraph>
+                    Install Baukasten in your Theia application:
+                </Paragraph>
+                <CodeBlock
+                    code="npm install baukasten-ui react react-dom"
+                    language="bash"
+                />
+            </Section>
+
+            <Section>
+                <Heading level={2}>Basic Setup</Heading>
+                <Paragraph>
+                    Import the base styles and Theia-specific CSS variables:
+                </Paragraph>
+                <CodeBlock
+                    code={`// Import base styles (required)
+import 'baukasten-ui/dist/baukasten-base.css';
+
+// Import Theia-specific CSS variables
+import 'baukasten-ui/dist/baukasten-theia.css';`}
+                    language="tsx"
+                />
+                <Paragraph>
+                    Then use components in your application:
+                </Paragraph>
+                <CodeBlock
+                    code={`import { Button, Input, Select, Alert } from 'baukasten-ui';
+
+function MyTheiaWidget() {
+  return (
+    <div style={{ padding: 'var(--bk-spacing-6)' }}>
+      <Alert variant="info" title="Eclipse Theia">
+        Your Theia widget is using Baukasten!
+      </Alert>
+      
+      <Select
+        options={[
+          { value: 'opt1', label: 'Option 1' },
+          { value: 'opt2', label: 'Option 2' },
+        ]}
+        placeholder="Select an option"
+        style={{ marginTop: 'var(--bk-spacing-4)' }}
+      />
+      
+      <Button variant="primary" style={{ marginTop: 'var(--bk-spacing-4)' }}>
+        Execute
+      </Button>
+    </div>
+  );
+}`}
+                    language="tsx"
+                />
+            </Section>
+
+            <Divider style={{ margin: 'var(--bk-spacing-8) 0' }} />
+
+            <Section>
+                <Heading level={2}>Multi-Window Support</Heading>
+                <Alert variant="warning" icon={<Icon name="warning" />} style={{ marginBottom: 'var(--bk-spacing-6)' }}>
+                    <strong>Important:</strong> If you're using Baukasten in Theia secondary/popup windows, you need to use <code style={{
+                        backgroundColor: 'var(--vscode-textCodeBlock-background)',
+                        padding: '2px 6px',
+                        borderRadius: 'var(--bk-radius-sm)',
+                    }}>PortalProvider</code> to ensure dropdowns and tooltips render correctly.
+                </Alert>
+
+                <Heading level={3}>The Problem</Heading>
+                <Paragraph>
+                    Portal-based components like Select, Dropdown, Tooltip, and ContextMenu render their floating
+                    content using React portals. By default, these portals target the main window's <code style={{
+                        backgroundColor: 'var(--vscode-textCodeBlock-background)',
+                        padding: '2px 6px',
+                        borderRadius: 'var(--bk-radius-sm)',
+                    }}>document.body</code>.
+                </Paragraph>
+                <Paragraph>
+                    In Theia's multi-window scenarios, when a component is rendered in a secondary window but its
+                    portal content goes to the main window's body, dropdowns appear on the wrong window!
+                </Paragraph>
+
+                <Heading level={3}>The Solution: PortalProvider</Heading>
+                <Paragraph>
+                    Wrap your secondary window content with <code style={{
+                        backgroundColor: 'var(--vscode-textCodeBlock-background)',
+                        padding: '2px 6px',
+                        borderRadius: 'var(--bk-radius-sm)',
+                    }}>PortalProvider</code> to redirect portal content to the correct window:
+                </Paragraph>
+                <CodeBlock
+                    code={`import { useRef, useState, useEffect } from 'react';
+import { PortalProvider, Select, Dropdown, Tooltip, Button } from 'baukasten-ui';
+
+function SecondaryWindowContent() {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [ready, setReady] = useState(false);
+  
+  // Wait for the ref to be available before rendering portal content
+  useEffect(() => {
+    setReady(true);
+  }, []);
+  
+  return (
+    <div ref={rootRef} style={{ height: '100%', width: '100%' }}>
+      {ready && (
+        <PortalProvider root={rootRef.current}>
+          {/* All portal content will now render in this window */}
+          
+          <Select
+            options={[
+              { value: 'ts', label: 'TypeScript' },
+              { value: 'js', label: 'JavaScript' },
+              { value: 'py', label: 'Python' },
+            ]}
+            placeholder="Select a language"
+          />
+          
+          <Dropdown trigger={<Button>Open Menu</Button>}>
+            <div style={{ padding: 'var(--bk-spacing-4)' }}>
+              Menu content appears in the correct window!
+            </div>
+          </Dropdown>
+          
+          <Tooltip content="This tooltip also renders correctly!">
+            <Button>Hover me</Button>
+          </Tooltip>
+        </PortalProvider>
+      )}
+    </div>
+  );
+}`}
+                    language="tsx"
+                />
+            </Section>
+
+            <Section>
+                <Heading level={2}>Components Using Portals</Heading>
+                <Paragraph>
+                    These components render floating content via portals and respect <code style={{
+                        backgroundColor: 'var(--vscode-textCodeBlock-background)',
+                        padding: '2px 6px',
+                        borderRadius: 'var(--bk-radius-sm)',
+                    }}>PortalProvider</code>:
+                </Paragraph>
+                <div style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+                    gap: 'var(--bk-spacing-4)',
+                    marginTop: 'var(--bk-spacing-4)',
+                }}>
+                    {[
+                        { name: 'Select', desc: 'Dropdown options list', path: '/components/select' },
+                        { name: 'Dropdown', desc: 'Generic dropdown container', path: '/components/dropdown' },
+                        { name: 'Tooltip', desc: 'Hover tooltips', path: '/components/tooltip' },
+                        { name: 'ContextMenu', desc: 'Right-click menus', path: '/components/contextmenu' },
+                        { name: 'ButtonGroup', desc: 'Split button dropdowns', path: '/components/buttongroup' },
+                    ].map(item => (
+                        <Link key={item.name} href={item.path} style={{ textDecoration: 'none' }}>
+                            <div style={{
+                                backgroundColor: 'var(--vscode-sideBar-background)',
+                                border: '1px solid var(--vscode-panel-border)',
+                                borderRadius: 'var(--bk-radius-md)',
+                                padding: 'var(--bk-spacing-4)',
+                                transition: 'border-color 0.2s',
+                            }}
+                                onMouseEnter={(e) => e.currentTarget.style.borderColor = 'var(--vscode-focusBorder)'}
+                                onMouseLeave={(e) => e.currentTarget.style.borderColor = 'var(--vscode-panel-border)'}>
+                                <Heading level={4} style={{ margin: '0 0 var(--bk-spacing-1) 0' }}>{item.name}</Heading>
+                                <span style={{ color: 'var(--vscode-descriptionForeground)', fontSize: 'var(--bk-font-size-sm)' }}>
+                                    {item.desc}
+                                </span>
+                            </div>
+                        </Link>
+                    ))}
+                </div>
+            </Section>
+
+            <Section>
+                <Heading level={2}>API Reference</Heading>
+
+                <Heading level={3}>PortalProvider</Heading>
+                <Paragraph>
+                    A context provider that configures where portal content should be rendered.
+                </Paragraph>
+                <CodeBlock
+                    code={`interface PortalProviderProps {
+  /**
+   * The root element where portals should be rendered.
+   * In multi-window apps, this should be an element in the current window.
+   */
+  root: HTMLElement | null;
+  
+  /**
+   * The content to render within this portal context.
+   */
+  children: React.ReactNode;
+}`}
+                    language="typescript"
+                />
+
+                <Heading level={3}>usePortalRoot Hook</Heading>
+                <Paragraph>
+                    A hook to access the portal root element. Useful if you're building custom portal-based components:
+                </Paragraph>
+                <CodeBlock
+                    code={`import { usePortalRoot } from 'baukasten-ui';
+import { FloatingPortal } from '@floating-ui/react';
+
+function CustomFloatingComponent() {
+  const portalRoot = usePortalRoot();
+  
+  return (
+    <FloatingPortal root={portalRoot}>
+      <div>My floating content</div>
+    </FloatingPortal>
+  );
+}`}
+                    language="tsx"
+                />
+            </Section>
+
+            <Section>
+                <Heading level={2}>Backward Compatibility</Heading>
+                <Paragraph>
+                    If <code style={{
+                        backgroundColor: 'var(--vscode-textCodeBlock-background)',
+                        padding: '2px 6px',
+                        borderRadius: 'var(--bk-radius-sm)',
+                    }}>PortalProvider</code> is not used, components fall back to their default behavior (rendering
+                    to <code style={{
+                        backgroundColor: 'var(--vscode-textCodeBlock-background)',
+                        padding: '2px 6px',
+                        borderRadius: 'var(--bk-radius-sm)',
+                    }}>document.body</code>). This means:
+                </Paragraph>
+                <ul style={{
+                    color: 'var(--bk-color-text-secondary)',
+                    lineHeight: 'var(--bk-line-height-relaxed)',
+                    paddingLeft: 'var(--bk-spacing-6)',
+                }}>
+                    <li style={{ marginBottom: 'var(--bk-spacing-2)' }}>Existing code continues to work without changes</li>
+                    <li style={{ marginBottom: 'var(--bk-spacing-2)' }}>Single-window applications don't need <code style={{
+                        backgroundColor: 'var(--vscode-textCodeBlock-background)',
+                        padding: '2px 6px',
+                        borderRadius: 'var(--bk-radius-sm)',
+                    }}>PortalProvider</code></li>
+                    <li>Only add <code style={{
+                        backgroundColor: 'var(--vscode-textCodeBlock-background)',
+                        padding: '2px 6px',
+                        borderRadius: 'var(--bk-radius-sm)',
+                    }}>PortalProvider</code> when using secondary windows in Theia</li>
+                </ul>
+            </Section>
+
+            <Divider style={{ margin: 'var(--bk-spacing-8) 0' }} />
+
+            <Alert variant="success" icon={<Icon name="check" />} title="You're Ready for Multi-Window!">
+                <Paragraph>
+                    Your Theia application is now ready to use Baukasten components in both main and secondary windows.
+                    For more component details, explore the <Link href="/components/select" style={{ color: 'var(--vscode-textLink-foreground)' }}>component documentation</Link>.
+                </Paragraph>
+            </Alert>
+        </PageLayout>
+    );
+}

--- a/packages/website/src/app/guides/vscode/page.tsx
+++ b/packages/website/src/app/guides/vscode/page.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import PageLayout from '@/components/PageLayout';
+import CodeBlock from '@/components/CodeBlock';
+import Link from 'next/link';
+import { Heading, Alert, Icon, Divider } from 'baukasten-ui';
+
+const Section = ({ children }: { children: React.ReactNode }) => (
+    <section style={{ marginBottom: 'var(--bk-spacing-12)' }}>{children}</section>
+);
+
+const Paragraph = ({ children }: { children: React.ReactNode }) => (
+    <p style={{
+        fontSize: 'var(--bk-font-size-md)',
+        color: 'var(--bk-color-text-secondary)',
+        margin: '0 0 var(--bk-spacing-4) 0',
+        lineHeight: 'var(--bk-line-height-relaxed)',
+    }}>{children}</p>
+);
+
+export default function VSCodeGuidePage() {
+    return (
+        <PageLayout
+            title="Usage in VS Code"
+            description="Learn how to use Baukasten components in VS Code webview extensions."
+        >
+            <Alert variant="info" icon={<Icon name="extensions" />} style={{ marginBottom: 'var(--bk-spacing-8)' }}>
+                Baukasten is designed to work seamlessly with VS Code webviews, automatically using VS Code's native theme variables for consistent styling.
+            </Alert>
+
+            <Section>
+                <Heading level={2}>Installation</Heading>
+                <Paragraph>
+                    Install Baukasten in your VS Code extension project:
+                </Paragraph>
+                <CodeBlock
+                    code="npm install baukasten-ui react react-dom"
+                    language="bash"
+                />
+            </Section>
+
+            <Section>
+                <Heading level={2}>Basic Setup</Heading>
+                <Paragraph>
+                    In your webview React application, import the styles and components:
+                </Paragraph>
+                <CodeBlock
+                    code={`import { GlobalStyles, Button, Input, Alert } from 'baukasten-ui';
+
+function App() {
+  return (
+    <>
+      <GlobalStyles />
+      <div style={{ padding: 'var(--bk-spacing-6)' }}>
+        <Alert variant="info" title="Welcome">
+          Your VS Code extension is using Baukasten!
+        </Alert>
+        
+        <Input 
+          label="Search" 
+          placeholder="Type to search..." 
+          style={{ marginTop: 'var(--bk-spacing-4)' }}
+        />
+        
+        <Button variant="primary" style={{ marginTop: 'var(--bk-spacing-4)' }}>
+          Search
+        </Button>
+      </div>
+    </>
+  );
+}
+
+export default App;`}
+                    language="tsx"
+                />
+            </Section>
+
+            <Section>
+                <Heading level={2}>Using CSS Files (Alternative)</Heading>
+                <Paragraph>
+                    Instead of using <code style={{
+                        backgroundColor: 'var(--vscode-textCodeBlock-background)',
+                        padding: '2px 6px',
+                        borderRadius: 'var(--bk-radius-sm)',
+                    }}>GlobalStyles</code>, you can import the pre-built CSS files:
+                </Paragraph>
+                <CodeBlock
+                    code={`// Import base styles (required)
+import 'baukasten-ui/dist/baukasten-base.css';
+
+// Import VS Code-specific CSS variables
+import 'baukasten-ui/dist/baukasten-vscode.css';`}
+                    language="tsx"
+                />
+            </Section>
+        </PageLayout>
+    );
+}

--- a/packages/website/src/components/Navigation.tsx
+++ b/packages/website/src/components/Navigation.tsx
@@ -50,6 +50,8 @@ const foundations = [
 
 const guides = [
   { name: 'Theming', path: '/guides/theming' },
+  { name: 'Usage in VS Code', path: '/guides/vscode' },
+  { name: 'Usage in Eclipse Theia', path: '/guides/theia' },
 ];
 
 const recipes = [


### PR DESCRIPTION


Introduce PortalProvider context and usePortalRoot hook to configure portal root elements for floating UI components. This enables proper rendering of dropdowns, tooltips, and menus in Theia secondary windows.

Changes:
- Add PortalProvider context with usePortalRoot hook
- Update Select, Dropdown, Tooltip, ContextMenu, and ButtonGroup to use portal root from context
- Export PortalProvider and related types from main package entry
- Add comprehensive documentation in CLAUDE.md and README.md
- Create dedicated guide pages for VS Code and Eclipse Theia usage
- Update navigation with new guide links


---

## Risk level:
- [x] Low risk (docs, tests, minor fixes)
- [ ] Medium risk (above average work, refactors)
- [ ] High risk (infra, critical changes)