### PR TITLE
Fix index.d.ts for some cases by bundling the types

### DIFF
--- a/packages/baukasten/vite.config.ts
+++ b/packages/baukasten/vite.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
     dts({
       insertTypesEntry: true,
       exclude: ["**/*.stories.tsx", "**/*.test.tsx", "**/*.test.ts"],
+      rollupTypes: true,
     }),
   ],
   build: {


### PR DESCRIPTION
This bundles the exportet types into a single d.ts. This should fix resolving the types in some cases of typescript configuration. Some module resolutions have a hard time with reexportet types

---

## Risk level:
- [ ] Low risk (docs, tests, minor fixes)
- [ ] Medium risk (above average work, refactors)
- [ ] High risk (infra, critical changes)
- [x] I don't know. Either this breaks everything or fixes type resolving