### PR TITLE
DataTable improvements

### DIFF
--- a/packages/baukasten/package.json
+++ b/packages/baukasten/package.json
@@ -52,6 +52,7 @@
     "build": "tsc --project tsconfig.build.json && vite build && npm run build:css",
     "build:css": "npx tsx scripts/generate-css.ts",
     "preview": "vite preview",
+    "watch": "vite build --watch --mode development",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",

--- a/packages/baukasten/src/components/DataTable/DataTable.css.ts
+++ b/packages/baukasten/src/components/DataTable/DataTable.css.ts
@@ -64,6 +64,7 @@ export const table = recipe({
         color: 'var(--bk-color-foreground)',
         fontFamily: 'inherit',
         backgroundColor: 'var(--bk-color-background)',
+        outline: 'none',
     },
     variants: {
         fullWidth: {
@@ -172,6 +173,7 @@ export const tableHeaderCell = recipe({
                         backgroundColor: 'transparent',
                         transition: 'var(--bk-transition-colors)',
                         pointerEvents: 'none',
+                        zIndex: -1,
                     },
                     '&:hover::after': {
                         backgroundColor: 'var(--bk-color-hover)',
@@ -214,8 +216,8 @@ export const headerContent = style({
 export const sortIndicator = recipe({
     base: {
         display: 'inline-flex',
+        alignItems: 'center',
         marginLeft: 'var(--bk-spacing-1)',
-        fontSize: '0.75em',
         opacity: 0.5,
         transition: 'var(--bk-transition-base)',
     },
@@ -276,12 +278,8 @@ export const tableRow = recipe({
     },
     variants: {
         variant: {
-            default: {
-                backgroundColor: 'var(--bk-color-background)',
-            },
-            zebra: {
-                backgroundColor: 'transparent',
-            },
+            default: {},
+            zebra: {},
         },
         selected: {
             true: {
@@ -325,7 +323,7 @@ export const zebraRow = style({});
 /**
  * Zebra striping for even rows
  */
-globalStyle(`tbody tr${zebraRow}:nth-child(even)`, {
+globalStyle(`tbody tr${zebraRow}:nth-child(even):not([data-selected])`, {
     backgroundColor: 'var(--bk-color-background-secondary)',
 });
 
@@ -347,11 +345,21 @@ export const tableCell = recipe({
             false: {},
         },
         size: cellSizes,
+        truncate: {
+            true: {
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                maxWidth: 0, // Forces the cell to respect the column width in fixed table layout
+            },
+            false: {},
+        },
     },
     defaultVariants: {
         align: 'left',
         bordered: true,
         size: 'md',
+        truncate: false,
     },
 });
 

--- a/packages/baukasten/src/components/DataTable/DataTable.tsx
+++ b/packages/baukasten/src/components/DataTable/DataTable.tsx
@@ -320,6 +320,9 @@ export function DataTable<TData>({
     style,
     'aria-label': ariaLabel,
 }: DataTableProps<TData>) {
+    // Ensure data is always an array to prevent TanStack Table errors
+    const safeData = data ?? [];
+
     // Internal state for uncontrolled mode
     const [internalSorting, setInternalSorting] = useState<SortingState>([]);
     const [internalPagination, setInternalPagination] = useState<PaginationState>({
@@ -337,7 +340,7 @@ export function DataTable<TData>({
 
     // Create the table instance
     const table = useReactTable({
-        data,
+        data: safeData,
         columns,
         state: {
             sorting,

--- a/packages/baukasten/src/components/DataTable/DataTable.tsx
+++ b/packages/baukasten/src/components/DataTable/DataTable.tsx
@@ -423,10 +423,10 @@ export function DataTable<TData>({
                 <div className={styles.headerContent}>
                     {header.isPlaceholder
                         ? null
-                        : flexRender(header.column.columnDef.header, header.getContext())}
+                        : flexRender(header.column.columnDef.header, header.getContext()) as React.ReactNode}
                     {canSort && (
                         <span className={styles.sortIndicator({ active: !!isSorted })}>
-                            {isSorted === 'asc' ? '▲' : isSorted === 'desc' ? '▼' : '▲'}
+                            <Icon name={isSorted === 'desc' ? 'chevron-down' : 'chevron-up'} />
                         </span>
                     )}
                 </div>
@@ -437,6 +437,8 @@ export function DataTable<TData>({
                         })}
                         onMouseDown={header.getResizeHandler()}
                         onTouchStart={header.getResizeHandler()}
+                        onClick={(e) => e.stopPropagation()}
+                        onDoubleClick={(e) => e.stopPropagation()}
                     />
                 )}
             </th>
@@ -451,18 +453,68 @@ export function DataTable<TData>({
                     align: (cell.column.columnDef.meta as { align?: DataTableColumnAlign })?.align ?? 'left',
                     bordered,
                     size,
+                    truncate: enableColumnResizing,
                 })}
                 style={{
                     width: cell.column.getSize(),
                 }}
             >
-                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                {flexRender(cell.column.columnDef.cell, cell.getContext()) as React.ReactNode}
             </td>
         );
     };
 
     const rows = table.getRowModel().rows;
     const isEmpty = rows.length === 0 && !loading;
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLTableElement>) => {
+        if (!enableRowSelection) {
+            return;
+        }
+
+        if (e.key === ' ') {
+            e.preventDefault();
+            const selectedIds = Object.keys(table.getState().rowSelection);
+            if (selectedIds.length === 1) {
+                const currentRow = rows.find((r) => r.id === selectedIds[0]);
+                if (currentRow) {
+                    if (enableMultiRowSelection) {
+                        currentRow.toggleSelected();
+                    } else {
+                        table.setRowSelection(currentRow.getIsSelected() ? {} : { [currentRow.id]: true });
+                    }
+                }
+            }
+            return;
+        }
+
+        if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') {
+            return;
+        }
+        e.preventDefault();
+
+        const selectedIds = Object.keys(table.getState().rowSelection);
+        const currentIndex = selectedIds.length === 1
+            ? rows.findIndex((r) => r.id === selectedIds[0])
+            : -1;
+
+        let nextIndex: number;
+        if (e.key === 'ArrowDown') {
+            nextIndex = currentIndex < rows.length - 1 ? currentIndex + 1 : currentIndex;
+        } else {
+            nextIndex = currentIndex > 0 ? currentIndex - 1 : 0;
+        }
+
+        const nextRow = rows[nextIndex];
+        if (nextRow) {
+            table.setRowSelection({ [nextRow.id]: true });
+            onRowSelectionChange?.({ [nextRow.id]: true });
+            // Scroll the newly selected row into view
+            const tableEl = e.currentTarget;
+            const rowEl = tableEl.querySelector<HTMLElement>(`tr[data-rowid="${nextRow.id}"]`);
+            rowEl?.scrollIntoView({ block: 'nearest' });
+        }
+    };
 
     return (
         <div className={`${styles.dataTableWrapper({ fillHeight })} ${className ?? ''}`} style={style}>
@@ -505,6 +557,8 @@ export function DataTable<TData>({
                     style={{
                         tableLayout: enableColumnResizing ? 'fixed' : undefined,
                     }}
+                    onKeyDown={enableRowSelection ? handleKeyDown : undefined}
+                    tabIndex={enableRowSelection ? 0 : undefined}
                 >
                     <thead className={styles.tableHead({ sticky: stickyHeader })}>
                         {table.getHeaderGroups().map((headerGroup) => (
@@ -537,13 +591,27 @@ export function DataTable<TData>({
                             rows.map((row) => (
                                 <tr
                                     key={row.id}
+                                    data-rowid={row.id}
+                                    data-selected={row.getIsSelected() || undefined}
                                     className={`${styles.tableRow({
                                         variant,
                                         selected: row.getIsSelected(),
                                         hoverable: !!onRowClick || !!enableRowSelection,
                                     })} ${variant === 'zebra' ? styles.zebraRow : ''}`.trim()}
-                                    onClick={onRowClick ? () => onRowClick(row) : undefined}
-                                    style={{ cursor: onRowClick ? 'pointer' : undefined }}
+                                    onClick={(e) => {
+                                        if (enableRowSelection) {
+                                            if (enableMultiRowSelection && (e.ctrlKey || e.metaKey)) {
+                                                // Multi-select: toggle individual row
+                                                row.toggleSelected();
+                                            } else {
+                                                // Single call to set selection to only this row,
+                                                // avoids stale state from separate reset + toggle calls
+                                                table.setRowSelection({ [row.id]: true });
+                                            }
+                                        }
+                                        onRowClick?.(row);
+                                    }}
+                                    style={{ cursor: (onRowClick || enableRowSelection) ? 'pointer' : undefined }}
                                 >
                                     {row.getVisibleCells().map(renderCell)}
                                 </tr>


### PR DESCRIPTION
<!-- Describe your changes above this line -->
Following improvements and bugfixes included:
- Nullsafe data property handling
- Add keyboard navigation (ArrowUp/Down, Space) for row selection
- Improve click-to-select: single click selects exclusively, Ctrl/Cmd
  for multi-select toggle
- Replace Unicode sort arrows with Icon component (chevron-up/down)
- Add cell text truncation when column resizing is enabled
- Prevent resizer clicks from triggering column sort
- Fix zebra striping to respect selected row state
- Fix sortable header hover overlay stacking context
- Add TypeScript casts for flexRender return values
---

## Risk level:
- [x] Low risk (docs, tests, minor fixes)
- [ ] Medium risk (above average work, refactors)
- [ ] High risk (infra, critical changes)