### PR TITLE
Fix vertical badge stretch

### DIFF
--- a/packages/baukasten/src/components/Badge/Badge.css.ts
+++ b/packages/baukasten/src/components/Badge/Badge.css.ts
@@ -10,6 +10,7 @@ export const badge = recipe({
         display: 'inline-flex',
         alignItems: 'center',
         justifyContent: 'center',
+        alignSelf: 'baseline',
         borderRadius: 'var(--bk-radius-full)',
         whiteSpace: 'nowrap',
         gap: 'var(--bk-gap-xs)',


### PR DESCRIPTION
<!-- Describe your changes above this line -->

Fixes badge stretching #41 


Before: 
<img width="689" height="213" alt="Bildschirmfoto 2026-05-11 um 15 33 57" src="https://github.com/user-attachments/assets/f16c2409-bfb5-49e2-8245-d3f94f6bbf90" />


After:

<img width="677" height="166" alt="Bildschirmfoto 2026-05-11 um 16 07 31" src="https://github.com/user-attachments/assets/26c49212-9512-491d-af41-409363531416" />


---

## Risk level:

- [x] Low risk (docs, tests, minor fixes)
- [ ] Medium risk (above average work, refactors)
- [ ] High risk (infra, critical changes)
