### PR TITLE
feat(tree): add tree component with expandable nodes and edge guides

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "build-storybook": "npm run build:web-wrapper && cd packages/baukasten && NODE_PATH=./node_modules npm run build-storybook",
         "website": "npm run dev --workspace=packages/website",
         "website:build": "npm run build --workspace=packages/website",
-        "website:start": "npm run start --workspace=packages/website",
+        "website:start": "npm run dev --workspace=packages/website",
         "example:web": "npm run dev --workspace=packages/examples/web-example",
         "example:vscode": "npm run watch --workspace=packages/examples/vscode",
         "build:vscode": "npm run build --workspace=packages/examples/vscode",

--- a/packages/baukasten/src/components/Tree/Tree.css.ts
+++ b/packages/baukasten/src/components/Tree/Tree.css.ts
@@ -1,0 +1,43 @@
+import { recipe } from '@vanilla-extract/recipes';
+
+/**
+ * Tree container styles
+ *
+ * The tree container provides the root-level styling and sets up
+ * CSS custom properties for edge color that child nodes inherit.
+ */
+export const treeContainer = recipe({
+    base: {
+        display: 'flex',
+        flexDirection: 'column',
+        outline: 'none',
+        userSelect: 'none',
+        vars: {
+            '--bk-tree-edge-color': 'var(--bk-color-border)',
+        },
+    },
+
+    variants: {
+        size: {
+            xs: {
+                fontSize: 'var(--bk-font-size-xs)',
+            },
+            sm: {
+                fontSize: 'var(--bk-font-size-sm)',
+            },
+            md: {
+                fontSize: 'var(--bk-font-size-md)',
+            },
+            lg: {
+                fontSize: 'var(--bk-font-size-base)',
+            },
+            xl: {
+                fontSize: 'var(--bk-font-size-lg)',
+            },
+        },
+    },
+
+    defaultVariants: {
+        size: 'md',
+    },
+});

--- a/packages/baukasten/src/components/Tree/Tree.stories.tsx
+++ b/packages/baukasten/src/components/Tree/Tree.stories.tsx
@@ -1,0 +1,761 @@
+import React, { useState, useCallback } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Tree, type TreeNodeData, type TreeEdgeStyle } from './';
+import { Icon } from '../Icon';
+import { IconButton } from '../IconButton';
+import { Badge } from '../Badge';
+import { Tooltip } from '../Tooltip';
+import { Heading, Paragraph, Text } from '../Typography';
+
+const meta = {
+    title: 'Components/Tree',
+    component: Tree,
+    parameters: {
+        layout: 'centered',
+        docs: {
+            description: {
+                component:
+                    'A hierarchical tree view component with expandable nodes, guide edge lines, keyboard navigation, icons, badges, and full ARIA support. Suitable for file explorers, settings hierarchies, navigation trees, and more.',
+            },
+        },
+    },
+    tags: ['autodocs'],
+    argTypes: {
+        size: {
+            control: 'select',
+            options: ['xs', 'sm', 'md', 'lg', 'xl'],
+            description: 'Size of tree items',
+            table: { defaultValue: { summary: 'md' } },
+        },
+        edgeStyle: {
+            control: 'select',
+            options: ['none', 'solid', 'dashed', 'dotted'],
+            description: 'Style of guide lines between parent and child',
+            table: { defaultValue: { summary: 'none' } },
+        },
+        indentSize: {
+            control: { type: 'range', min: 8, max: 40, step: 4 },
+            description: 'Indentation per level in pixels',
+            table: { defaultValue: { summary: '20' } },
+        },
+        selectable: {
+            control: 'boolean',
+            description: 'Whether nodes can be selected',
+            table: { defaultValue: { summary: 'true' } },
+        },
+        expandOnClick: {
+            control: 'boolean',
+            description: 'Whether clicking the row toggles expansion',
+            table: { defaultValue: { summary: 'true' } },
+        },
+    },
+} satisfies Meta<typeof Tree>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ─── Sample data ─────────────────────────────────────────────────────────────
+
+const fileTreeNodes: TreeNodeData[] = [
+    {
+        id: 'src',
+        label: 'src',
+        icon: <Icon name="folder" />,
+        children: [
+            {
+                id: 'src/components',
+                label: 'components',
+                icon: <Icon name="folder" />,
+                children: [
+                    {
+                        id: 'src/components/Button.tsx',
+                        label: 'Button.tsx',
+                        icon: <Icon name="file" />,
+                    },
+                    {
+                        id: 'src/components/Input.tsx',
+                        label: 'Input.tsx',
+                        icon: <Icon name="file" />,
+                    },
+                    {
+                        id: 'src/components/Modal.tsx',
+                        label: 'Modal.tsx',
+                        icon: <Icon name="file" />,
+                    },
+                ],
+            },
+            {
+                id: 'src/styles',
+                label: 'styles',
+                icon: <Icon name="folder" />,
+                children: [
+                    {
+                        id: 'src/styles/tokens.ts',
+                        label: 'tokens.ts',
+                        icon: <Icon name="file" />,
+                    },
+                    {
+                        id: 'src/styles/global.css',
+                        label: 'global.css',
+                        icon: <Icon name="file" />,
+                    },
+                ],
+            },
+            {
+                id: 'src/index.ts',
+                label: 'index.ts',
+                icon: <Icon name="file" />,
+            },
+            {
+                id: 'src/App.tsx',
+                label: 'App.tsx',
+                icon: <Icon name="file" />,
+            },
+        ],
+    },
+    {
+        id: 'package.json',
+        label: 'package.json',
+        icon: <Icon name="file" />,
+    },
+    {
+        id: 'tsconfig.json',
+        label: 'tsconfig.json',
+        icon: <Icon name="file" />,
+    },
+    {
+        id: 'README.md',
+        label: 'README.md',
+        icon: <Icon name="file" />,
+    },
+];
+
+const settingsNodes: TreeNodeData[] = [
+    {
+        id: 'general',
+        label: 'General',
+        icon: <Icon name="gear" />,
+        children: [
+            { id: 'general/language', label: 'Language', icon: <Icon name="globe" /> },
+            {
+                id: 'general/theme',
+                label: 'Theme',
+                icon: <Icon name="symbol-color" />,
+                badge: <Badge variant="info" size="sm">New</Badge>,
+            },
+            {
+                id: 'general/font',
+                label: 'Font',
+                icon: <Icon name="text-size" />,
+            },
+        ],
+    },
+    {
+        id: 'editor',
+        label: 'Editor',
+        icon: <Icon name="edit" />,
+        children: [
+            { id: 'editor/tab-size', label: 'Tab Size', icon: <Icon name="whitespace" /> },
+            {
+                id: 'editor/word-wrap',
+                label: 'Word Wrap',
+                icon: <Icon name="word-wrap" />,
+            },
+            {
+                id: 'editor/minimap',
+                label: 'Minimap',
+                icon: <Icon name="preview" />,
+                disabled: true,
+            },
+            {
+                id: 'editor/formatting',
+                label: 'Formatting',
+                icon: <Icon name="list-ordered" />,
+                children: [
+                    {
+                        id: 'editor/formatting/on-save',
+                        label: 'Format On Save',
+                    },
+                    {
+                        id: 'editor/formatting/on-paste',
+                        label: 'Format On Paste',
+                    },
+                    {
+                        id: 'editor/formatting/on-type',
+                        label: 'Format On Type',
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        id: 'extensions',
+        label: 'Extensions',
+        icon: <Icon name="extensions" />,
+        badge: <Badge variant="default" size="sm">12</Badge>,
+        children: [
+            { id: 'ext/eslint', label: 'ESLint', icon: <Icon name="check" /> },
+            { id: 'ext/prettier', label: 'Prettier', icon: <Icon name="check" /> },
+            {
+                id: 'ext/gitlens',
+                label: 'GitLens',
+                icon: <Icon name="git-merge" />,
+                badge: <Badge variant="warning" size="sm">Update</Badge>,
+            },
+        ],
+    },
+    {
+        id: 'security',
+        label: 'Security',
+        icon: <Icon name="shield" />,
+        disabled: true,
+        children: [
+            { id: 'security/auth', label: 'Authentication' },
+            { id: 'security/permissions', label: 'Permissions' },
+        ],
+    },
+];
+
+// ─── Stories ─────────────────────────────────────────────────────────────────
+
+/**
+ * Interactive playground with all tree properties exposed.
+ */
+export const Interactive: Story = {
+    render: (args) => (
+        <Tree
+            {...args}
+            nodes={fileTreeNodes}
+            defaultExpandedKeys={['src', 'src/components']}
+            style={{ width: '350px' }}
+        />
+    ),
+    args: {
+        size: 'md',
+        edgeStyle: 'none',
+        indentSize: 20,
+        selectable: true,
+        expandOnClick: true,
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'Interactive playground to explore all tree properties. Use the controls to experiment with different sizes, edge styles, and behaviours.',
+            },
+        },
+    },
+};
+
+/**
+ * Basic file explorer tree with icons and default expansion.
+ */
+export const FileExplorer: Story = {
+    render: () => (
+        <Tree
+            nodes={fileTreeNodes}
+            defaultExpandedKeys={['src', 'src/components']}
+            style={{ width: '350px' }}
+        />
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'A typical file explorer layout with folder and file icons. Nodes can be expanded by clicking.',
+            },
+        },
+    },
+};
+
+/**
+ * Tree with solid guide lines connecting parent and child nodes.
+ */
+export const WithSolidEdges: Story = {
+    render: () => (
+        <Tree
+            nodes={fileTreeNodes}
+            edgeStyle="solid"
+            defaultExpandedKeys={['src', 'src/components', 'src/styles']}
+            style={{ width: '350px' }}
+        />
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Solid guide lines between parent and child nodes for clear visual hierarchy.',
+            },
+        },
+    },
+};
+
+/**
+ * Tree with dashed guide lines.
+ */
+export const WithDashedEdges: Story = {
+    render: () => (
+        <Tree
+            nodes={fileTreeNodes}
+            edgeStyle="dashed"
+            defaultExpandedKeys={['src', 'src/components', 'src/styles']}
+            style={{ width: '350px' }}
+        />
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Dashed guide lines for a lighter visual style.',
+            },
+        },
+    },
+};
+
+/**
+ * Tree with dotted guide lines.
+ */
+export const WithDottedEdges: Story = {
+    render: () => (
+        <Tree
+            nodes={fileTreeNodes}
+            edgeStyle="dotted"
+            defaultExpandedKeys={['src', 'src/components', 'src/styles']}
+            style={{ width: '350px' }}
+        />
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Dotted guide lines for a subtle visual connector.',
+            },
+        },
+    },
+};
+
+/**
+ * Settings tree with badges, disabled nodes, and nested levels.
+ */
+export const SettingsTree: Story = {
+    render: () => (
+        <Tree
+            nodes={settingsNodes}
+            defaultExpandedKeys={['general', 'editor', 'editor/formatting']}
+            edgeStyle="solid"
+            style={{ width: '350px' }}
+        />
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'A settings panel tree demonstrating badges on nodes, disabled state, and multi-level nesting.',
+            },
+        },
+    },
+};
+
+/**
+ * Controlled expansion and selection.
+ */
+export const Controlled: Story = {
+    render: () => {
+        const [expandedKeys, setExpandedKeys] = useState<string[]>(['src']);
+        const [selectedKey, setSelectedKey] = useState<string | null>(null);
+
+        return (
+            <div style={{ display: 'flex', gap: 'var(--bk-gap-xl)' }}>
+                <Tree
+                    nodes={fileTreeNodes}
+                    expandedKeys={expandedKeys}
+                    onExpandChange={(keys) => setExpandedKeys(keys)}
+                    selectedKey={selectedKey}
+                    onSelect={(key) => setSelectedKey(key)}
+                    style={{ width: '300px' }}
+                />
+                <div style={{ minWidth: '200px' }}>
+                    <Heading level={5} marginBottom>State</Heading>
+                    <Text size="sm" color="muted" block>
+                        Selected: {selectedKey ?? '(none)'}
+                    </Text>
+                    <Text size="sm" color="muted" block style={{ marginTop: 'var(--bk-spacing-2)' }}>
+                        Expanded: {expandedKeys.length > 0 ? expandedKeys.join(', ') : '(none)'}
+                    </Text>
+                </div>
+            </div>
+        );
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'Fully controlled tree with external state for expanded keys and selected key. The state panel on the right shows current values.',
+            },
+        },
+    },
+};
+
+/**
+ * Custom expand icon using a render function.
+ */
+export const CustomExpandIcon: Story = {
+    render: () => (
+        <Tree
+            nodes={fileTreeNodes}
+            defaultExpandedKeys={['src', 'src/components']}
+            expandIcon={({ expanded, hasChildren }) => {
+                if (!hasChildren) return <Icon name="dash" />;
+                return expanded ? <Icon name="fold-down" /> : <Icon name="fold" />;
+            }}
+            style={{ width: '350px' }}
+        />
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Custom expand/collapse icons via the `expandIcon` render prop. Here we use fold/unfold icons instead of the default chevron.',
+            },
+        },
+    },
+};
+
+/**
+ * Tree at different sizes.
+ */
+export const Sizes: Story = {
+    render: () => {
+        const sizes = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
+        return (
+            <div style={{ display: 'flex', gap: 'var(--bk-spacing-8)', flexWrap: 'wrap' }}>
+                {sizes.map((size) => (
+                    <div key={size}>
+                        <Heading level={5} marginBottom>
+                            {size.toUpperCase()}
+                        </Heading>
+                        <Tree
+                            nodes={[
+                                {
+                                    id: `${size}-root`,
+                                    label: 'Root',
+                                    icon: <Icon name="folder" />,
+                                    children: [
+                                        { id: `${size}-a`, label: 'Child A', icon: <Icon name="file" /> },
+                                        { id: `${size}-b`, label: 'Child B', icon: <Icon name="file" /> },
+                                    ],
+                                },
+                            ]}
+                            size={size}
+                            defaultExpandedKeys={[`${size}-root`]}
+                            style={{ width: '220px' }}
+                        />
+                    </div>
+                ))}
+            </div>
+        );
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'All available sizes from xs to xl, matching the component sizing system used across baukasten.',
+            },
+        },
+    },
+};
+
+/**
+ * Edge style comparison side by side.
+ */
+export const EdgeStyleComparison: Story = {
+    render: () => {
+        const styles: TreeEdgeStyle[] = ['none', 'solid', 'dashed', 'dotted'];
+        const simpleNodes: TreeNodeData[] = [
+            {
+                id: 'root',
+                label: 'Root',
+                icon: <Icon name="folder" />,
+                children: [
+                    {
+                        id: 'child-1',
+                        label: 'Child 1',
+                        icon: <Icon name="folder" />,
+                        children: [
+                            { id: 'leaf-1', label: 'Leaf 1', icon: <Icon name="file" /> },
+                            { id: 'leaf-2', label: 'Leaf 2', icon: <Icon name="file" /> },
+                        ],
+                    },
+                    { id: 'child-2', label: 'Child 2', icon: <Icon name="file" /> },
+                    { id: 'child-3', label: 'Child 3', icon: <Icon name="file" /> },
+                ],
+            },
+        ];
+
+        return (
+            <div style={{ display: 'flex', gap: 'var(--bk-spacing-8)', flexWrap: 'wrap' }}>
+                {styles.map((edgeStyle) => (
+                    <div key={edgeStyle}>
+                        <Heading level={5} marginBottom>
+                            {edgeStyle}
+                        </Heading>
+                        <Tree
+                            nodes={simpleNodes}
+                            edgeStyle={edgeStyle}
+                            defaultExpandedKeys={['root', 'child-1']}
+                            style={{ width: '220px' }}
+                        />
+                    </div>
+                ))}
+            </div>
+        );
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'Side-by-side comparison of all four edge styles: none, solid, dashed, and dotted.',
+            },
+        },
+    },
+};
+
+/**
+ * Folder actions — add subfolder, add file, delete — using IconButtons in the badge slot.
+ */
+export const WithActionButtons: Story = {
+    render: () => {
+        let nextId = 100;
+
+        const FolderActions: React.FC<{
+            nodeId: string;
+            onAddFolder: (parentId: string) => void;
+            onAddFile: (parentId: string) => void;
+            onDelete: (nodeId: string) => void;
+        }> = ({ nodeId, onAddFolder, onAddFile, onDelete }) => (
+            <span
+                style={{ display: 'inline-flex', gap: 'var(--bk-gap-xs)' }}
+                // Stop propagation so clicking buttons doesn't toggle expand or select
+                onClick={(e) => e.stopPropagation()}
+            >
+                <Tooltip content="New folder" placement="top">
+                    <IconButton
+                        icon={<Icon name="new-folder" />}
+                        variant="ghost"
+                        size="xs"
+                        aria-label="New folder"
+                        onClick={() => onAddFolder(nodeId)}
+                    />
+                </Tooltip>
+                <Tooltip content="New file" placement="top">
+                    <IconButton
+                        icon={<Icon name="new-file" />}
+                        variant="ghost"
+                        size="xs"
+                        aria-label="New file"
+                        onClick={() => onAddFile(nodeId)}
+                    />
+                </Tooltip>
+                <Tooltip content="Delete" placement="top">
+                    <IconButton
+                        icon={<Icon name="trash" />}
+                        variant="ghost"
+                        size="xs"
+                        aria-label="Delete"
+                        onClick={() => onDelete(nodeId)}
+                    />
+                </Tooltip>
+            </span>
+        );
+
+        const ActionTreeDemo = () => {
+            const buildInitialNodes = useCallback((): TreeNodeData[] => {
+                const makeFolder = (
+                    id: string,
+                    label: string,
+                    children: TreeNodeData[],
+                ): TreeNodeData => ({
+                    id,
+                    label,
+                    icon: <Icon name="folder" />,
+                    children,
+                    // badge will be patched dynamically below
+                });
+
+                const makeFile = (id: string, label: string): TreeNodeData => ({
+                    id,
+                    label,
+                    icon: <Icon name="file" />,
+                });
+
+                return [
+                    makeFolder('project', 'my-project', [
+                        makeFolder('project/src', 'src', [
+                            makeFolder('project/src/components', 'components', [
+                                makeFile('project/src/components/App.tsx', 'App.tsx'),
+                                makeFile('project/src/components/Header.tsx', 'Header.tsx'),
+                            ]),
+                            makeFile('project/src/index.ts', 'index.ts'),
+                        ]),
+                        makeFolder('project/public', 'public', [
+                            makeFile('project/public/index.html', 'index.html'),
+                        ]),
+                        makeFile('project/package.json', 'package.json'),
+                    ]),
+                ];
+            }, []);
+
+            const [nodes, setNodes] = useState<TreeNodeData[]>(buildInitialNodes);
+            const [expandedKeys, setExpandedKeys] = useState<string[]>([
+                'project',
+                'project/src',
+                'project/src/components',
+            ]);
+
+            // Deep-insert a child node under a given parent id
+            const insertChild = (
+                tree: TreeNodeData[],
+                parentId: string,
+                child: TreeNodeData,
+            ): TreeNodeData[] =>
+                tree.map((n) => {
+                    if (n.id === parentId) {
+                        return { ...n, children: [...(n.children ?? []), child] };
+                    }
+                    if (n.children) {
+                        return { ...n, children: insertChild(n.children, parentId, child) };
+                    }
+                    return n;
+                });
+
+            // Deep-remove a node by id
+            const removeNode = (tree: TreeNodeData[], targetId: string): TreeNodeData[] =>
+                tree
+                    .filter((n) => n.id !== targetId)
+                    .map((n) =>
+                        n.children ? { ...n, children: removeNode(n.children, targetId) } : n,
+                    );
+
+            const handleAddFolder = useCallback((parentId: string) => {
+                const id = `folder-${++nextId}`;
+                const newFolder: TreeNodeData = {
+                    id,
+                    label: `new-folder-${nextId}`,
+                    icon: <Icon name="folder" />,
+                    children: [],
+                };
+                setNodes((prev) => insertChild(prev, parentId, newFolder));
+                setExpandedKeys((prev) => (prev.includes(parentId) ? prev : [...prev, parentId]));
+            }, []);
+
+            const handleAddFile = useCallback((parentId: string) => {
+                const id = `file-${++nextId}`;
+                const newFile: TreeNodeData = {
+                    id,
+                    label: `untitled-${nextId}.ts`,
+                    icon: <Icon name="file" />,
+                };
+                setNodes((prev) => insertChild(prev, parentId, newFile));
+                setExpandedKeys((prev) => (prev.includes(parentId) ? prev : [...prev, parentId]));
+            }, []);
+
+            const handleDelete = useCallback((nodeId: string) => {
+                setNodes((prev) => removeNode(prev, nodeId));
+            }, []);
+
+            // Recursively attach badge actions to every folder node
+            const attachActions = (tree: TreeNodeData[]): TreeNodeData[] =>
+                tree.map((n) => {
+                    const isFolder = !!(n.children);
+                    const patched: TreeNodeData = {
+                        ...n,
+                        badge: isFolder ? (
+                            <FolderActions
+                                nodeId={n.id}
+                                onAddFolder={handleAddFolder}
+                                onAddFile={handleAddFile}
+                                onDelete={handleDelete}
+                            />
+                        ) : undefined,
+                    };
+                    if (n.children) {
+                        patched.children = attachActions(n.children);
+                    }
+                    return patched;
+                });
+
+            return (
+                <Tree
+                    nodes={attachActions(nodes)}
+                    edgeStyle="solid"
+                    expandedKeys={expandedKeys}
+                    onExpandChange={(keys) => setExpandedKeys(keys)}
+                    style={{ width: '400px' }}
+                />
+            );
+        };
+
+        return <ActionTreeDemo />;
+    },
+    parameters: {
+        docs: {
+            description: {
+                story:
+                    'Folder nodes with action buttons (add subfolder, add file, delete) in the badge slot. ' +
+                    'Clicking an action button modifies the tree data without triggering node selection or expand. ' +
+                    'This pattern works because `badge` accepts any `ReactNode` — buttons, dropdowns, or custom controls.',
+            },
+        },
+    },
+};
+
+/**
+ * Comprehensive showcase.
+ */
+export const Showcase: Story = {
+    render: () => (
+        <div
+            style={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 'var(--bk-spacing-8)',
+                padding: 'var(--bk-spacing-8)',
+                maxWidth: '1200px',
+                margin: '0 auto',
+            }}
+        >
+            <div>
+                <Heading level={2} marginBottom>
+                    Tree Component Showcase
+                </Heading>
+                <Paragraph size="base" color="muted">
+                    A hierarchical tree view with expandable nodes, guide lines, icons, badges,
+                    and keyboard navigation.
+                </Paragraph>
+            </div>
+
+            <div style={{ display: 'flex', gap: 'var(--bk-spacing-8)', flexWrap: 'wrap' }}>
+                <div>
+                    <Heading level={3} marginBottom>
+                        File Explorer
+                    </Heading>
+                    <Tree
+                        nodes={fileTreeNodes}
+                        defaultExpandedKeys={['src', 'src/components']}
+                        style={{ width: '320px' }}
+                    />
+                </div>
+
+                <div>
+                    <Heading level={3} marginBottom>
+                        Settings (with edges)
+                    </Heading>
+                    <Tree
+                        nodes={settingsNodes}
+                        defaultExpandedKeys={['general', 'editor']}
+                        edgeStyle="solid"
+                        style={{ width: '320px' }}
+                    />
+                </div>
+            </div>
+        </div>
+    ),
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                story: 'Complete showcase of all tree features side by side.',
+            },
+        },
+    },
+};

--- a/packages/baukasten/src/components/Tree/Tree.stories.tsx
+++ b/packages/baukasten/src/components/Tree/Tree.stories.tsx
@@ -54,6 +54,27 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+// ─── Tree-mutation helpers (module-scope so stories can use them with stable
+//     references inside useCallback) ───────────────────────────────────────────
+
+function insertChild(tree: TreeNodeData[], parentId: string, child: TreeNodeData): TreeNodeData[] {
+    return tree.map((n) => {
+        if (n.id === parentId) {
+            return { ...n, children: [...(n.children ?? []), child] };
+        }
+        if (n.children) {
+            return { ...n, children: insertChild(n.children, parentId, child) };
+        }
+        return n;
+    });
+}
+
+function removeNode(tree: TreeNodeData[], targetId: string): TreeNodeData[] {
+    return tree
+        .filter((n) => n.id !== targetId)
+        .map((n) => (n.children ? { ...n, children: removeNode(n.children, targetId) } : n));
+}
+
 // ─── Sample data ─────────────────────────────────────────────────────────────
 
 const fileTreeNodes: TreeNodeData[] = [
@@ -628,30 +649,6 @@ export const WithActionButtons: Story = {
                 'project/src',
                 'project/src/components',
             ]);
-
-            // Deep-insert a child node under a given parent id
-            const insertChild = (
-                tree: TreeNodeData[],
-                parentId: string,
-                child: TreeNodeData,
-            ): TreeNodeData[] =>
-                tree.map((n) => {
-                    if (n.id === parentId) {
-                        return { ...n, children: [...(n.children ?? []), child] };
-                    }
-                    if (n.children) {
-                        return { ...n, children: insertChild(n.children, parentId, child) };
-                    }
-                    return n;
-                });
-
-            // Deep-remove a node by id
-            const removeNode = (tree: TreeNodeData[], targetId: string): TreeNodeData[] =>
-                tree
-                    .filter((n) => n.id !== targetId)
-                    .map((n) =>
-                        n.children ? { ...n, children: removeNode(n.children, targetId) } : n,
-                    );
 
             const handleAddFolder = useCallback((parentId: string) => {
                 const id = `folder-${++nextId}`;

--- a/packages/baukasten/src/components/Tree/Tree.stories.tsx
+++ b/packages/baukasten/src/components/Tree/Tree.stories.tsx
@@ -141,7 +141,11 @@ const settingsNodes: TreeNodeData[] = [
                 id: 'general/theme',
                 label: 'Theme',
                 icon: <Icon name="symbol-color" />,
-                badge: <Badge variant="info" size="sm">New</Badge>,
+                badge: (
+                    <Badge variant="info" size="sm">
+                        New
+                    </Badge>
+                ),
             },
             {
                 id: 'general/font',
@@ -192,7 +196,11 @@ const settingsNodes: TreeNodeData[] = [
         id: 'extensions',
         label: 'Extensions',
         icon: <Icon name="extensions" />,
-        badge: <Badge variant="default" size="sm">12</Badge>,
+        badge: (
+            <Badge variant="default" size="sm">
+                12
+            </Badge>
+        ),
         children: [
             { id: 'ext/eslint', label: 'ESLint', icon: <Icon name="check" /> },
             { id: 'ext/prettier', label: 'Prettier', icon: <Icon name="check" /> },
@@ -200,7 +208,11 @@ const settingsNodes: TreeNodeData[] = [
                 id: 'ext/gitlens',
                 label: 'GitLens',
                 icon: <Icon name="git-merge" />,
-                badge: <Badge variant="warning" size="sm">Update</Badge>,
+                badge: (
+                    <Badge variant="warning" size="sm">
+                        Update
+                    </Badge>
+                ),
             },
         ],
     },
@@ -369,11 +381,18 @@ export const Controlled: Story = {
                     style={{ width: '300px' }}
                 />
                 <div style={{ minWidth: '200px' }}>
-                    <Heading level={5} marginBottom>State</Heading>
+                    <Heading level={5} marginBottom>
+                        State
+                    </Heading>
                     <Text size="sm" color="muted" block>
                         Selected: {selectedKey ?? '(none)'}
                     </Text>
-                    <Text size="sm" color="muted" block style={{ marginTop: 'var(--bk-spacing-2)' }}>
+                    <Text
+                        size="sm"
+                        color="muted"
+                        block
+                        style={{ marginTop: 'var(--bk-spacing-2)' }}
+                    >
                         Expanded: {expandedKeys.length > 0 ? expandedKeys.join(', ') : '(none)'}
                     </Text>
                 </div>
@@ -433,8 +452,16 @@ export const Sizes: Story = {
                                     label: 'Root',
                                     icon: <Icon name="folder" />,
                                     children: [
-                                        { id: `${size}-a`, label: 'Child A', icon: <Icon name="file" /> },
-                                        { id: `${size}-b`, label: 'Child B', icon: <Icon name="file" /> },
+                                        {
+                                            id: `${size}-a`,
+                                            label: 'Child A',
+                                            icon: <Icon name="file" />,
+                                        },
+                                        {
+                                            id: `${size}-b`,
+                                            label: 'Child B',
+                                            icon: <Icon name="file" />,
+                                        },
                                     ],
                                 },
                             ]}
@@ -656,7 +683,7 @@ export const WithActionButtons: Story = {
             // Recursively attach badge actions to every folder node
             const attachActions = (tree: TreeNodeData[]): TreeNodeData[] =>
                 tree.map((n) => {
-                    const isFolder = !!(n.children);
+                    const isFolder = !!n.children;
                     const patched: TreeNodeData = {
                         ...n,
                         badge: isFolder ? (
@@ -719,8 +746,8 @@ export const Showcase: Story = {
                     Tree Component Showcase
                 </Heading>
                 <Paragraph size="base" color="muted">
-                    A hierarchical tree view with expandable nodes, guide lines, icons, badges,
-                    and keyboard navigation.
+                    A hierarchical tree view with expandable nodes, guide lines, icons, badges, and
+                    keyboard navigation.
                 </Paragraph>
             </div>
 

--- a/packages/baukasten/src/components/Tree/Tree.tsx
+++ b/packages/baukasten/src/components/Tree/Tree.tsx
@@ -157,10 +157,7 @@ export const useTreeContext = () => useContext(TreeContext);
 /**
  * Collect all node IDs in depth-first order (for keyboard navigation).
  */
-function flattenVisibleIds(
-    nodes: TreeNodeData[],
-    expandedKeys: Set<string>,
-): string[] {
+function flattenVisibleIds(nodes: TreeNodeData[], expandedKeys: Set<string>): string[] {
     const result: string[] = [];
     const walk = (list: TreeNodeData[]) => {
         for (const node of list) {
@@ -242,9 +239,7 @@ export const Tree: React.FC<TreeProps> = ({
     const [internalExpanded, setInternalExpanded] = useState<Set<string>>(
         () => new Set(defaultExpandedKeys),
     );
-    const expandedKeys = isExpandControlled
-        ? new Set(controlledExpandedKeys)
-        : internalExpanded;
+    const expandedKeys = isExpandControlled ? new Set(controlledExpandedKeys) : internalExpanded;
 
     const toggleExpand = useCallback(
         (key: string, node: TreeNodeData) => {
@@ -302,8 +297,7 @@ export const Tree: React.FC<TreeProps> = ({
             const visibleIds = flattenVisibleIds(nodes, expandedKeys);
             if (visibleIds.length === 0) return;
 
-            const currentId =
-                document.activeElement?.getAttribute('data-tree-node-id') ?? null;
+            const currentId = document.activeElement?.getAttribute('data-tree-node-id') ?? null;
             const currentIndex = currentId ? visibleIds.indexOf(currentId) : -1;
 
             const focusNode = (id: string) => {
@@ -314,15 +308,13 @@ export const Tree: React.FC<TreeProps> = ({
             switch (e.key) {
                 case 'ArrowDown': {
                     e.preventDefault();
-                    const nextIdx =
-                        currentIndex < visibleIds.length - 1 ? currentIndex + 1 : 0;
+                    const nextIdx = currentIndex < visibleIds.length - 1 ? currentIndex + 1 : 0;
                     focusNode(visibleIds[nextIdx]);
                     break;
                 }
                 case 'ArrowUp': {
                     e.preventDefault();
-                    const prevIdx =
-                        currentIndex > 0 ? currentIndex - 1 : visibleIds.length - 1;
+                    const prevIdx = currentIndex > 0 ? currentIndex - 1 : visibleIds.length - 1;
                     focusNode(visibleIds[prevIdx]);
                     break;
                 }

--- a/packages/baukasten/src/components/Tree/Tree.tsx
+++ b/packages/baukasten/src/components/Tree/Tree.tsx
@@ -1,0 +1,434 @@
+import React, { createContext, useContext, useCallback, useMemo, useState, useRef } from 'react';
+import { type Size } from '../../styles';
+import { treeContainer } from './Tree.css';
+import { TreeNodeComponent } from './TreeNode';
+
+// ─── Public types ────────────────────────────────────────────────────────────
+
+/**
+ * Data shape for each node in the tree.
+ */
+export interface TreeNodeData {
+    /** Unique identifier for the node */
+    id: string;
+    /** Label displayed in the node row */
+    label: React.ReactNode;
+    /** Optional icon rendered before the label */
+    icon?: React.ReactNode;
+    /** Optional content rendered on the right side (badges, actions, etc.) */
+    badge?: React.ReactNode;
+    /** Child nodes */
+    children?: TreeNodeData[];
+    /** Whether the node is disabled */
+    disabled?: boolean;
+}
+
+/**
+ * Edge style between parent and child nodes
+ */
+export type TreeEdgeStyle = 'solid' | 'dashed' | 'dotted' | 'none';
+
+/**
+ * Props for the custom expand icon render function
+ */
+export interface ExpandIconRenderProps {
+    expanded: boolean;
+    node: TreeNodeData;
+    hasChildren: boolean;
+}
+
+/**
+ * Tree component props
+ */
+export interface TreeProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSelect'> {
+    /** Array of root-level tree nodes */
+    nodes: TreeNodeData[];
+
+    /**
+     * Size of the tree items
+     * @default 'md'
+     */
+    size?: Size;
+
+    // ─── Expansion ──────────────────────────────────────────────────────
+
+    /**
+     * Controlled expanded node keys
+     */
+    expandedKeys?: string[];
+
+    /**
+     * Default expanded node keys (uncontrolled)
+     * @default []
+     */
+    defaultExpandedKeys?: string[];
+
+    /**
+     * Called when nodes are expanded or collapsed
+     */
+    onExpandChange?: (
+        expandedKeys: string[],
+        info: { key: string; expanded: boolean; node: TreeNodeData },
+    ) => void;
+
+    // ─── Selection ──────────────────────────────────────────────────────
+
+    /**
+     * Whether nodes can be selected
+     * @default true
+     */
+    selectable?: boolean;
+
+    /**
+     * Controlled selected node key
+     */
+    selectedKey?: string | null;
+
+    /**
+     * Default selected node key (uncontrolled)
+     */
+    defaultSelectedKey?: string | null;
+
+    /**
+     * Called when a node is selected
+     */
+    onSelect?: (key: string, node: TreeNodeData) => void;
+
+    // ─── Customization ──────────────────────────────────────────────────
+
+    /**
+     * Custom expand/collapse icon renderer.
+     * Returning `null` hides the icon. A built-in chevron-right icon is used by default.
+     */
+    expandIcon?: (props: ExpandIconRenderProps) => React.ReactNode;
+
+    /**
+     * Style of the guide lines connecting parent and child nodes
+     * @default 'none'
+     */
+    edgeStyle?: TreeEdgeStyle;
+
+    /**
+     * Indentation per level in pixels
+     * @default 20
+     */
+    indentSize?: number;
+
+    /**
+     * Whether clicking the entire row toggles expand (true) or only the icon (false)
+     * @default true
+     */
+    expandOnClick?: boolean;
+}
+
+// ─── Context ─────────────────────────────────────────────────────────────────
+
+export interface TreeContextValue {
+    size: Size;
+    edgeStyle: TreeEdgeStyle;
+    indentSize: number;
+    selectable: boolean;
+    expandOnClick: boolean;
+    expandedKeys: Set<string>;
+    selectedKey: string | null;
+    expandIcon?: (props: ExpandIconRenderProps) => React.ReactNode;
+    toggleExpand: (key: string, node: TreeNodeData) => void;
+    selectNode: (key: string, node: TreeNodeData) => void;
+    registerNode: (id: string, element: HTMLElement | null) => void;
+}
+
+const TreeContext = createContext<TreeContextValue>({
+    size: 'md',
+    edgeStyle: 'none',
+    indentSize: 20,
+    selectable: true,
+    expandOnClick: true,
+    expandedKeys: new Set(),
+    selectedKey: null,
+    toggleExpand: () => {},
+    selectNode: () => {},
+    registerNode: () => {},
+});
+
+export const useTreeContext = () => useContext(TreeContext);
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Collect all node IDs in depth-first order (for keyboard navigation).
+ */
+function flattenVisibleIds(
+    nodes: TreeNodeData[],
+    expandedKeys: Set<string>,
+): string[] {
+    const result: string[] = [];
+    const walk = (list: TreeNodeData[]) => {
+        for (const node of list) {
+            result.push(node.id);
+            if (node.children?.length && expandedKeys.has(node.id)) {
+                walk(node.children);
+            }
+        }
+    };
+    walk(nodes);
+    return result;
+}
+
+/**
+ * Find a node by id in the tree data.
+ */
+function findNode(nodes: TreeNodeData[], id: string): TreeNodeData | undefined {
+    for (const node of nodes) {
+        if (node.id === id) return node;
+        if (node.children) {
+            const found = findNode(node.children, id);
+            if (found) return found;
+        }
+    }
+    return undefined;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+/**
+ * Tree component
+ *
+ * A hierarchical tree view with expandable nodes, customisable guide edges,
+ * icons, badges, keyboard navigation, and full ARIA support.
+ *
+ * @example
+ * ```tsx
+ * // Basic
+ * <Tree
+ *   nodes={[
+ *     { id: '1', label: 'Folder A', children: [
+ *       { id: '1-1', label: 'File 1' },
+ *       { id: '1-2', label: 'File 2' },
+ *     ]},
+ *     { id: '2', label: 'Folder B', children: [] },
+ *   ]}
+ * />
+ *
+ * // With guide lines
+ * <Tree nodes={nodes} edgeStyle="solid" />
+ *
+ * // Controlled expansion
+ * <Tree
+ *   nodes={nodes}
+ *   expandedKeys={expandedKeys}
+ *   onExpandChange={setExpandedKeys}
+ * />
+ * ```
+ */
+export const Tree: React.FC<TreeProps> = ({
+    nodes,
+    size = 'md',
+    expandedKeys: controlledExpandedKeys,
+    defaultExpandedKeys = [],
+    onExpandChange,
+    selectable = true,
+    selectedKey: controlledSelectedKey,
+    defaultSelectedKey = null,
+    onSelect,
+    expandIcon,
+    edgeStyle = 'none',
+    indentSize = 20,
+    expandOnClick = true,
+    className,
+    ...props
+}) => {
+    // ── Expansion state (controlled / uncontrolled) ──────────────────────
+    const isExpandControlled = controlledExpandedKeys !== undefined;
+    const [internalExpanded, setInternalExpanded] = useState<Set<string>>(
+        () => new Set(defaultExpandedKeys),
+    );
+    const expandedKeys = isExpandControlled
+        ? new Set(controlledExpandedKeys)
+        : internalExpanded;
+
+    const toggleExpand = useCallback(
+        (key: string, node: TreeNodeData) => {
+            const isExpanded = expandedKeys.has(key);
+            const next = new Set(expandedKeys);
+            if (isExpanded) {
+                next.delete(key);
+            } else {
+                next.add(key);
+            }
+
+            if (!isExpandControlled) {
+                setInternalExpanded(next);
+            }
+            onExpandChange?.(Array.from(next), {
+                key,
+                expanded: !isExpanded,
+                node,
+            });
+        },
+        [expandedKeys, isExpandControlled, onExpandChange],
+    );
+
+    // ── Selection state (controlled / uncontrolled) ─────────────────────
+    const isSelectControlled = controlledSelectedKey !== undefined;
+    const [internalSelected, setInternalSelected] = useState<string | null>(defaultSelectedKey);
+    const selectedKey = isSelectControlled ? controlledSelectedKey : internalSelected;
+
+    const selectNode = useCallback(
+        (key: string, node: TreeNodeData) => {
+            if (!selectable) return;
+            if (node.disabled) return;
+            if (!isSelectControlled) {
+                setInternalSelected(key);
+            }
+            onSelect?.(key, node);
+        },
+        [selectable, isSelectControlled, onSelect],
+    );
+
+    // ── Node element registry (for keyboard focus management) ───────────
+    const nodeElementsRef = useRef<Map<string, HTMLElement>>(new Map());
+
+    const registerNode = useCallback((id: string, element: HTMLElement | null) => {
+        if (element) {
+            nodeElementsRef.current.set(id, element);
+        } else {
+            nodeElementsRef.current.delete(id);
+        }
+    }, []);
+
+    // ── Keyboard navigation ─────────────────────────────────────────────
+    const handleKeyDown = useCallback(
+        (e: React.KeyboardEvent<HTMLDivElement>) => {
+            const visibleIds = flattenVisibleIds(nodes, expandedKeys);
+            if (visibleIds.length === 0) return;
+
+            const currentId =
+                document.activeElement?.getAttribute('data-tree-node-id') ?? null;
+            const currentIndex = currentId ? visibleIds.indexOf(currentId) : -1;
+
+            const focusNode = (id: string) => {
+                const el = nodeElementsRef.current.get(id);
+                el?.focus();
+            };
+
+            switch (e.key) {
+                case 'ArrowDown': {
+                    e.preventDefault();
+                    const nextIdx =
+                        currentIndex < visibleIds.length - 1 ? currentIndex + 1 : 0;
+                    focusNode(visibleIds[nextIdx]);
+                    break;
+                }
+                case 'ArrowUp': {
+                    e.preventDefault();
+                    const prevIdx =
+                        currentIndex > 0 ? currentIndex - 1 : visibleIds.length - 1;
+                    focusNode(visibleIds[prevIdx]);
+                    break;
+                }
+                case 'ArrowRight': {
+                    e.preventDefault();
+                    if (currentId) {
+                        const node = findNode(nodes, currentId);
+                        if (node?.children?.length) {
+                            if (!expandedKeys.has(currentId)) {
+                                toggleExpand(currentId, node);
+                            } else {
+                                // Move focus to first child
+                                const firstChildId = node.children[0].id;
+                                focusNode(firstChildId);
+                            }
+                        }
+                    }
+                    break;
+                }
+                case 'ArrowLeft': {
+                    e.preventDefault();
+                    if (currentId) {
+                        const node = findNode(nodes, currentId);
+                        if (node?.children?.length && expandedKeys.has(currentId)) {
+                            toggleExpand(currentId, node);
+                        }
+                        // else could move focus to parent — not implemented here for simplicity
+                    }
+                    break;
+                }
+                case 'Home': {
+                    e.preventDefault();
+                    focusNode(visibleIds[0]);
+                    break;
+                }
+                case 'End': {
+                    e.preventDefault();
+                    focusNode(visibleIds[visibleIds.length - 1]);
+                    break;
+                }
+                case 'Enter':
+                case ' ': {
+                    e.preventDefault();
+                    if (currentId) {
+                        const node = findNode(nodes, currentId);
+                        if (node && !node.disabled) {
+                            selectNode(currentId, node);
+                            if (node.children?.length && expandOnClick) {
+                                toggleExpand(currentId, node);
+                            }
+                        }
+                    }
+                    break;
+                }
+            }
+        },
+        [nodes, expandedKeys, toggleExpand, selectNode, expandOnClick],
+    );
+
+    // ── Context value ───────────────────────────────────────────────────
+    const contextValue = useMemo<TreeContextValue>(
+        () => ({
+            size,
+            edgeStyle,
+            indentSize,
+            selectable,
+            expandOnClick,
+            expandedKeys,
+            selectedKey: selectedKey ?? null,
+            expandIcon,
+            toggleExpand,
+            selectNode,
+            registerNode,
+        }),
+        [
+            size,
+            edgeStyle,
+            indentSize,
+            selectable,
+            expandOnClick,
+            expandedKeys,
+            selectedKey,
+            expandIcon,
+            toggleExpand,
+            selectNode,
+            registerNode,
+        ],
+    );
+
+    const containerClassName = className
+        ? `${treeContainer({ size })} ${className}`
+        : treeContainer({ size });
+
+    return (
+        <TreeContext.Provider value={contextValue}>
+            <div
+                role="tree"
+                aria-label={props['aria-label'] ?? 'Tree'}
+                className={containerClassName}
+                onKeyDown={handleKeyDown}
+                {...props}
+            >
+                {nodes.map((node) => (
+                    <TreeNodeComponent key={node.id} node={node} depth={0} />
+                ))}
+            </div>
+        </TreeContext.Provider>
+    );
+};

--- a/packages/baukasten/src/components/Tree/Tree.tsx
+++ b/packages/baukasten/src/components/Tree/Tree.tsx
@@ -239,7 +239,10 @@ export const Tree: React.FC<TreeProps> = ({
     const [internalExpanded, setInternalExpanded] = useState<Set<string>>(
         () => new Set(defaultExpandedKeys),
     );
-    const expandedKeys = isExpandControlled ? new Set(controlledExpandedKeys) : internalExpanded;
+    const expandedKeys = useMemo(
+        () => (isExpandControlled ? new Set(controlledExpandedKeys) : internalExpanded),
+        [isExpandControlled, controlledExpandedKeys, internalExpanded],
+    );
 
     const toggleExpand = useCallback(
         (key: string, node: TreeNodeData) => {

--- a/packages/baukasten/src/components/Tree/TreeNode.css.ts
+++ b/packages/baukasten/src/components/Tree/TreeNode.css.ts
@@ -1,0 +1,463 @@
+import { recipe } from '@vanilla-extract/recipes';
+import { style, globalStyle } from '@vanilla-extract/css';
+
+/**
+ * Tree node wrapper — wraps the row + its children sub-tree.
+ */
+export const treeNodeWrapper = style({
+    display: 'flex',
+    flexDirection: 'column',
+});
+
+/**
+ * Tree node row — the clickable/focusable horizontal strip.
+ */
+export const treeNodeRow = recipe({
+    base: {
+        display: 'flex',
+        alignItems: 'center',
+        borderRadius: 'var(--bk-radius-sm)',
+        transition: 'var(--bk-transition-colors)',
+        color: 'var(--bk-color-foreground)',
+        backgroundColor: 'transparent',
+        cursor: 'pointer',
+        border: 'none',
+        width: '100%',
+        fontFamily: 'inherit',
+        fontSize: 'inherit',
+        // Tight line height keeps single-line rows compact and lets the
+        // per-size minHeight (not the text box) decide the row height.
+        lineHeight: 'var(--bk-line-height-tight)',
+        textAlign: 'left',
+        outline: 'none',
+
+        selectors: {
+            '&:focus-visible': {
+                outline: 'var(--bk-border-width-2) solid var(--bk-color-list-focus-outline)',
+                outlineOffset: 'calc(-1 * var(--bk-border-width-2))',
+            },
+        },
+    },
+
+    variants: {
+        // Row heights come from the spacing scale, NOT --bk-size-* (which is
+        // the interactive-control height scale, tuned for click targets on
+        // buttons/inputs). A tree row is a scannable list row — density beats
+        // hit-target comfort — so it gets its own tighter scale.
+        size: {
+            xs: {
+                padding: 'var(--bk-spacing-0-5) var(--bk-spacing-1-5)',
+                gap: 'var(--bk-gap-xs)',
+                minHeight: 'var(--bk-spacing-4)',
+            },
+            sm: {
+                padding: 'var(--bk-spacing-0-5) var(--bk-spacing-2)',
+                gap: 'var(--bk-gap-xs)',
+                minHeight: 'var(--bk-spacing-5)',
+            },
+            md: {
+                padding: 'var(--bk-spacing-0-5) var(--bk-spacing-2)',
+                gap: 'var(--bk-gap-sm)',
+                minHeight: 'var(--bk-spacing-6)',
+            },
+            lg: {
+                padding: 'var(--bk-spacing-1) var(--bk-spacing-2-5)',
+                gap: 'var(--bk-gap-md)',
+                minHeight: 'var(--bk-spacing-7)',
+            },
+            xl: {
+                padding: 'var(--bk-spacing-1-5) var(--bk-spacing-3)',
+                gap: 'var(--bk-gap-md)',
+                minHeight: 'var(--bk-spacing-8)',
+            },
+        },
+        selected: {
+            true: {
+                backgroundColor: 'var(--bk-color-list-active)',
+                color: 'var(--bk-color-list-active-foreground)',
+            },
+            false: {},
+        },
+        disabled: {
+            true: {
+                opacity: 'var(--bk-opacity-disabled)',
+                cursor: 'not-allowed',
+            },
+            false: {},
+        },
+    },
+
+    defaultVariants: {
+        size: 'md',
+        selected: false,
+        disabled: false,
+    },
+});
+
+/**
+ * Hover and active states — only when not disabled and not selected.
+ */
+const rowBase = treeNodeRow.classNames.base;
+
+globalStyle(`${rowBase}:hover:not([aria-disabled="true"]):not([aria-selected="true"])`, {
+    backgroundColor: 'var(--bk-color-list-hover)',
+});
+
+globalStyle(`${rowBase}:active:not([aria-disabled="true"])`, {
+    backgroundColor: 'var(--bk-color-list-active)',
+});
+
+/**
+ * SVG icon sizing within tree rows
+ */
+globalStyle(`${rowBase} svg`, {
+    width: '1em',
+    height: '1em',
+    flexShrink: 0,
+});
+
+/**
+ * Expand icon container
+ */
+export const expandIconWrapper = recipe({
+    base: {
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexShrink: 0,
+        transition: 'transform var(--bk-transition-base)',
+    },
+
+    variants: {
+        expanded: {
+            true: {
+                transform: 'rotate(90deg)',
+            },
+            false: {
+                transform: 'rotate(0deg)',
+            },
+        },
+    },
+
+    defaultVariants: {
+        expanded: false,
+    },
+});
+
+/**
+ * Placeholder spacer for leaf nodes (aligns with expand icon width).
+ */
+export const expandIconSpacer = style({
+    display: 'inline-flex',
+    width: '1em',
+    flexShrink: 0,
+});
+
+/**
+ * Node icon container (the custom icon before the label)
+ */
+export const nodeIconWrapper = style({
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+});
+
+/**
+ * Node label — fills remaining space
+ */
+export const nodeLabel = style({
+    flex: 1,
+    minWidth: 0,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+});
+
+/**
+ * Right-side badge / action area
+ */
+export const nodeBadge = style({
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 'var(--bk-gap-xs)',
+    marginLeft: 'auto',
+    paddingLeft: 'var(--bk-spacing-2)',
+    flexShrink: 0,
+    color: 'var(--bk-color-foreground-muted)',
+    fontSize: '0.875em',
+});
+
+// ─── Children container with tree-edge guides ────────────────────────────────
+
+/**
+ * Children wrapper — rendered beneath the parent row.
+ * Uses CSS Grid animation for smooth expand/collapse.
+ */
+export const childrenContainer = recipe({
+    base: {
+        display: 'grid',
+        position: 'relative',
+        transition:
+            'grid-template-rows var(--bk-transition-slow), opacity var(--bk-transition-base)',
+    },
+
+    variants: {
+        isOpen: {
+            true: {
+                gridTemplateRows: '1fr',
+                opacity: 1,
+            },
+            false: {
+                gridTemplateRows: '0fr',
+                opacity: 0,
+            },
+        },
+    },
+
+    defaultVariants: {
+        isOpen: false,
+    },
+});
+
+/**
+ * Inner children wrapper — required for CSS Grid animation.
+ */
+export const childrenInner = style({
+    overflow: 'hidden',
+    minHeight: 0,
+});
+
+// ─── Edge guide styles ───────────────────────────────────────────────────────
+
+/**
+ * Each child node is wrapped in an edge-guide container that draws the
+ * connector lines from parent to child.  The indent is applied here.
+ */
+export const edgeGuideContainer = recipe({
+    base: {
+        position: 'relative',
+    },
+
+    variants: {
+        edgeStyle: {
+            solid: {},
+            dashed: {},
+            dotted: {},
+            none: {},
+        },
+    },
+
+    defaultVariants: {
+        edgeStyle: 'solid',
+    },
+});
+
+/**
+ * Vertical edge line for a single node's row.
+ *
+ * `edgeGuideContainer` wraps ONLY the row, so its height equals one row.
+ * That lets the line be positioned with pure percentages, no row-height
+ * variable needed:
+ *  - `top: -50%` reaches half a row up — to the parent / previous-sibling
+ *    row centre (the previous wrapper is exactly one row above).
+ *  - `height: 100%` ends the line at this row's own centre.
+ *  - `height: 150%` extends it to this row's bottom, where the
+ *    `edgeChildLine` (drawn on the children group) takes over.
+ *
+ * `extendDown` is true only for an expanded parent that has a sibling
+ * below it — the one case where the line must continue past the row.
+ */
+export const edgeVerticalLine = recipe({
+    base: {
+        selectors: {
+            '&::before': {
+                content: '""',
+                position: 'absolute',
+                top: '-50%',
+                left: 'var(--bk-tree-indent-center)',
+                width: 0,
+                borderLeftWidth: 'var(--bk-border-width-1)',
+                borderLeftColor: 'var(--bk-tree-edge-color)',
+            },
+        },
+    },
+
+    variants: {
+        edgeStyle: {
+            solid: {
+                selectors: {
+                    '&::before': {
+                        borderLeftStyle: 'solid',
+                    },
+                },
+            },
+            dashed: {
+                selectors: {
+                    '&::before': {
+                        borderLeftStyle: 'dashed',
+                    },
+                },
+            },
+            dotted: {
+                selectors: {
+                    '&::before': {
+                        borderLeftStyle: 'dotted',
+                    },
+                },
+            },
+            none: {
+                selectors: {
+                    '&::before': {
+                        display: 'none',
+                    },
+                },
+            },
+        },
+        extendDown: {
+            true: {
+                selectors: {
+                    // Reach this row's bottom to meet the children-group line
+                    '&::before': {
+                        height: '150%',
+                    },
+                },
+            },
+            false: {
+                selectors: {
+                    // Stop at this row's centre
+                    '&::before': {
+                        height: '100%',
+                    },
+                },
+            },
+        },
+    },
+
+    defaultVariants: {
+        edgeStyle: 'solid',
+        extendDown: false,
+    },
+});
+
+/**
+ * Horizontal connector from the vertical line to the node row.
+ * Drawn using an ::after pseudo-element.
+ */
+export const edgeHorizontalLine = recipe({
+    base: {
+        selectors: {
+            '&::after': {
+                content: '""',
+                position: 'absolute',
+                top: '50%',
+                left: 'var(--bk-tree-indent-center)',
+                width: 'var(--bk-tree-branch-width)',
+                height: 0,
+                borderTopWidth: 'var(--bk-border-width-1)',
+                borderTopColor: 'var(--bk-tree-edge-color)',
+            },
+        },
+    },
+
+    variants: {
+        edgeStyle: {
+            solid: {
+                selectors: {
+                    '&::after': {
+                        borderTopStyle: 'solid',
+                    },
+                },
+            },
+            dashed: {
+                selectors: {
+                    '&::after': {
+                        borderTopStyle: 'dashed',
+                    },
+                },
+            },
+            dotted: {
+                selectors: {
+                    '&::after': {
+                        borderTopStyle: 'dotted',
+                    },
+                },
+            },
+            none: {
+                selectors: {
+                    '&::after': {
+                        display: 'none',
+                    },
+                },
+            },
+        },
+    },
+
+    defaultVariants: {
+        edgeStyle: 'solid',
+    },
+});
+
+/**
+ * Vertical edge line drawn on a node's children group.
+ *
+ * `childrenContainer` spans the node's entire expanded subtree, so this
+ * `::before` carries the guide line *through* that subtree — from the
+ * node's row bottom down to its next sibling — keeping the line unbroken
+ * when a folder is expanded. Applied only to non-last nodes (a last node
+ * has no sibling below to connect to). Sits at the node's own indent
+ * column, so it reuses the same `--bk-tree-indent-center` value as the row.
+ */
+export const edgeChildLine = recipe({
+    base: {
+        selectors: {
+            '&::before': {
+                content: '""',
+                position: 'absolute',
+                top: 0,
+                bottom: 0,
+                left: 'var(--bk-tree-indent-center)',
+                width: 0,
+                borderLeftWidth: 'var(--bk-border-width-1)',
+                borderLeftColor: 'var(--bk-tree-edge-color)',
+            },
+        },
+    },
+
+    variants: {
+        edgeStyle: {
+            solid: {
+                selectors: {
+                    '&::before': {
+                        borderLeftStyle: 'solid',
+                    },
+                },
+            },
+            dashed: {
+                selectors: {
+                    '&::before': {
+                        borderLeftStyle: 'dashed',
+                    },
+                },
+            },
+            dotted: {
+                selectors: {
+                    '&::before': {
+                        borderLeftStyle: 'dotted',
+                    },
+                },
+            },
+            none: {
+                selectors: {
+                    '&::before': {
+                        display: 'none',
+                    },
+                },
+            },
+        },
+    },
+
+    defaultVariants: {
+        edgeStyle: 'solid',
+    },
+});

--- a/packages/baukasten/src/components/Tree/TreeNode.tsx
+++ b/packages/baukasten/src/components/Tree/TreeNode.tsx
@@ -1,0 +1,245 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import { Icon } from '../Icon';
+import { useTreeContext, type TreeNodeData } from './Tree';
+import {
+    treeNodeWrapper,
+    treeNodeRow,
+    expandIconWrapper,
+    expandIconSpacer,
+    nodeIconWrapper,
+    nodeLabel,
+    nodeBadge,
+    childrenContainer,
+    childrenInner,
+    edgeGuideContainer,
+    edgeVerticalLine,
+    edgeHorizontalLine,
+    edgeChildLine,
+} from './TreeNode.css';
+
+/**
+ * Props for the internal TreeNode component.
+ */
+interface TreeNodeComponentProps {
+    /** The node data to render */
+    node: TreeNodeData;
+    /** Current nesting depth (0 for root) */
+    depth: number;
+    /** Whether this node is the last sibling in its group */
+    isLast?: boolean;
+}
+
+/**
+ * Horizontal inset (px) between a row's indent edge and its content.
+ * Shared by the row's `paddingLeft` and the edge connector width so the
+ * horizontal guide line reaches exactly to where the content begins.
+ */
+const ROW_CONTENT_INSET = 8;
+
+/**
+ * TreeNodeComponent (internal)
+ *
+ * Recursively renders a tree node and its children.
+ * Draws edge guides when the tree has `edgeStyle` other than 'none'.
+ */
+export const TreeNodeComponent: React.FC<TreeNodeComponentProps> = ({
+    node,
+    depth,
+    isLast = false,
+}) => {
+    const {
+        size,
+        edgeStyle,
+        indentSize,
+        selectable,
+        expandOnClick,
+        expandedKeys,
+        selectedKey,
+        expandIcon: customExpandIcon,
+        toggleExpand,
+        selectNode,
+        registerNode,
+    } = useTreeContext();
+
+    const rowRef = useRef<HTMLDivElement>(null);
+    const hasChildren = !!(node.children && node.children.length > 0);
+    const isExpanded = expandedKeys.has(node.id);
+    const isSelected = selectedKey === node.id;
+
+    // Register / unregister in the node-elements map
+    useEffect(() => {
+        registerNode(node.id, rowRef.current);
+        return () => registerNode(node.id, null);
+    }, [node.id, registerNode]);
+
+    // ── Click handler ────────────────────────────────────────────────────
+    const handleRowClick = useCallback(
+        (e: React.MouseEvent) => {
+            if (node.disabled) return;
+            e.stopPropagation();
+
+            if (selectable) {
+                selectNode(node.id, node);
+            }
+
+            if (hasChildren && expandOnClick) {
+                toggleExpand(node.id, node);
+            }
+        },
+        [node, hasChildren, selectable, expandOnClick, selectNode, toggleExpand],
+    );
+
+    const handleExpandClick = useCallback(
+        (e: React.MouseEvent) => {
+            if (node.disabled) return;
+            e.stopPropagation();
+            toggleExpand(node.id, node);
+        },
+        [node, toggleExpand],
+    );
+
+    // ── Expand icon ──────────────────────────────────────────────────────
+    const renderExpandIcon = () => {
+        if (customExpandIcon) {
+            const custom = customExpandIcon({
+                expanded: isExpanded,
+                node,
+                hasChildren,
+            });
+            if (custom === null) return null;
+            return (
+                <span
+                    className={expandIconWrapper({ expanded: false })}
+                    onClick={!expandOnClick ? handleExpandClick : undefined}
+                    role="presentation"
+                >
+                    {custom}
+                </span>
+            );
+        }
+
+        if (!hasChildren) {
+            return <span className={expandIconSpacer} />;
+        }
+
+        return (
+            <span
+                className={expandIconWrapper({ expanded: isExpanded })}
+                onClick={!expandOnClick ? handleExpandClick : undefined}
+                role="presentation"
+            >
+                <Icon name="chevron-right" />
+            </span>
+        );
+    };
+
+    // ── Indent calculation ───────────────────────────────────────────────
+    const showEdges = edgeStyle !== 'none' && depth > 0;
+    const indentPx = depth * indentSize;
+    // Center of the indent gutter (for edge lines), relative to the left of this node's row
+    // The indent center is at "parentIndent + indentSize/2"
+    const indentCenterPx = (depth - 1) * indentSize + indentSize / 2;
+    // Horizontal branch width from the vertical line to the node content.
+    // Reaches from the indent gutter centre all the way to the row content,
+    // which sits ROW_CONTENT_INSET past the indent edge.
+    const branchWidthPx = indentSize / 2 + ROW_CONTENT_INSET;
+
+    // A leaf with no custom expand icon still renders an invisible 1em
+    // spacer where the chevron would sit. Extend the connector across that
+    // spacer so it ends where the chevron's right edge would be — the
+    // connector "stands in" for the missing chevron, leaving the same row
+    // gap before the icon that a chevron row has.
+    const hasSpacerOnly = !customExpandIcon && !hasChildren;
+    const branchWidth = hasSpacerOnly
+        ? `calc(${branchWidthPx}px + 1em)`
+        : `${branchWidthPx}px`;
+
+    // ── CSS custom properties for edge positioning ──────────────────────
+    const edgeVars: React.CSSProperties = showEdges
+        ? ({
+              '--bk-tree-indent-center': `${indentCenterPx}px`,
+              '--bk-tree-branch-width': branchWidth,
+          } as React.CSSProperties)
+        : {};
+
+    // ── Row element ──────────────────────────────────────────────────────
+    const rowClassName = treeNodeRow({
+        size,
+        selected: isSelected,
+        disabled: node.disabled ?? false,
+    });
+
+    const row = (
+        <div
+            ref={rowRef}
+            role="treeitem"
+            aria-expanded={hasChildren ? isExpanded : undefined}
+            aria-selected={selectable ? isSelected : undefined}
+            aria-disabled={node.disabled ?? false}
+            tabIndex={isSelected ? 0 : -1}
+            data-tree-node-id={node.id}
+            className={rowClassName}
+            style={{ paddingLeft: `${indentPx + ROW_CONTENT_INSET}px` }}
+            onClick={handleRowClick}
+        >
+            {renderExpandIcon()}
+            {node.icon && <span className={nodeIconWrapper}>{node.icon}</span>}
+            <span className={nodeLabel}>{node.label}</span>
+            {node.badge && <span className={nodeBadge}>{node.badge}</span>}
+        </div>
+    );
+
+    // ── Children ─────────────────────────────────────────────────────────
+    // When this node has a sibling below it, its children group carries the
+    // guide line through the (potentially expanded) subtree to that sibling.
+    const showChildConnector = showEdges && !isLast;
+    const childGroupClassName = showChildConnector
+        ? `${childrenContainer({ isOpen: isExpanded })} ${edgeChildLine({ edgeStyle })}`
+        : childrenContainer({ isOpen: isExpanded });
+
+    const children = hasChildren ? (
+        <div
+            className={childGroupClassName}
+            role="group"
+            style={showChildConnector ? edgeVars : undefined}
+        >
+            <div className={childrenInner}>
+                {node.children!.map((child, index) => (
+                    <TreeNodeComponent
+                        key={child.id}
+                        node={child}
+                        depth={depth + 1}
+                        isLast={index === node.children!.length - 1}
+                    />
+                ))}
+            </div>
+        </div>
+    ) : null;
+
+    // ── Wrap with edge guides if needed ──────────────────────────────────
+    if (showEdges) {
+        // For nodes with edges, we wrap the row + children in a container
+        // that draws the vertical + horizontal connector lines.
+        const edgeClasses = [
+            edgeGuideContainer({ edgeStyle }),
+            edgeVerticalLine({ edgeStyle, extendDown: !isLast && hasChildren && isExpanded }),
+            edgeHorizontalLine({ edgeStyle }),
+        ].join(' ');
+
+        return (
+            <div className={treeNodeWrapper}>
+                <div className={edgeClasses} style={edgeVars}>
+                    {row}
+                </div>
+                {children}
+            </div>
+        );
+    }
+
+    return (
+        <div className={treeNodeWrapper}>
+            {row}
+            {children}
+        </div>
+    );
+};

--- a/packages/baukasten/src/components/Tree/TreeNode.tsx
+++ b/packages/baukasten/src/components/Tree/TreeNode.tsx
@@ -150,9 +150,7 @@ export const TreeNodeComponent: React.FC<TreeNodeComponentProps> = ({
     // connector "stands in" for the missing chevron, leaving the same row
     // gap before the icon that a chevron row has.
     const hasSpacerOnly = !customExpandIcon && !hasChildren;
-    const branchWidth = hasSpacerOnly
-        ? `calc(${branchWidthPx}px + 1em)`
-        : `${branchWidthPx}px`;
+    const branchWidth = hasSpacerOnly ? `calc(${branchWidthPx}px + 1em)` : `${branchWidthPx}px`;
 
     // ── CSS custom properties for edge positioning ──────────────────────
     const edgeVars: React.CSSProperties = showEdges

--- a/packages/baukasten/src/components/Tree/index.ts
+++ b/packages/baukasten/src/components/Tree/index.ts
@@ -1,0 +1,8 @@
+export { Tree } from './Tree';
+export type {
+    TreeProps,
+    TreeNodeData,
+    TreeEdgeStyle,
+    ExpandIconRenderProps,
+    TreeContextValue,
+} from './Tree';

--- a/packages/baukasten/src/extra.ts
+++ b/packages/baukasten/src/extra.ts
@@ -94,3 +94,13 @@ export type { HeroProps } from './components/Hero';
 
 export { Avatar } from './components/Avatar';
 export type { AvatarProps, AvatarShape } from './components/Avatar';
+
+// ─── Tree ───────────────────────────────────────────────────────────────────
+
+export { Tree } from './components/Tree';
+export type {
+    TreeProps,
+    TreeNodeData,
+    TreeEdgeStyle,
+    ExpandIconRenderProps,
+} from './components/Tree';

--- a/packages/website/src/app/components/tree/page.tsx
+++ b/packages/website/src/app/components/tree/page.tsx
@@ -1,0 +1,743 @@
+'use client';
+
+import { useRef, useState, type MouseEvent } from 'react';
+import PageLayout from '@/components/PageLayout';
+import { Showcase, PropDefinition } from '@/components/ComponentShowcase';
+import { Icon, Badge, Text, Input } from 'baukasten-ui/core';
+import { Tree, ContextMenu, MenuItem, MenuDivider } from 'baukasten-ui/extra';
+import type { TreeNodeData } from 'baukasten-ui/extra';
+
+const treeProps: PropDefinition[] = [
+    {
+        name: 'nodes',
+        type: 'TreeNodeData[]',
+        required: true,
+        description: 'Array of root-level tree nodes.',
+    },
+    {
+        name: 'size',
+        type: '"xs" | "sm" | "md" | "lg" | "xl"',
+        default: '"md"',
+        description: 'Size of tree items.',
+    },
+    {
+        name: 'expandedKeys',
+        type: 'string[]',
+        description: 'Controlled set of expanded node IDs.',
+    },
+    {
+        name: 'defaultExpandedKeys',
+        type: 'string[]',
+        default: '[]',
+        description: 'Uncontrolled default expanded node IDs.',
+    },
+    {
+        name: 'onExpandChange',
+        type: '(expandedKeys: string[], info: { key, expanded, node }) => void',
+        description: 'Called when a node is expanded or collapsed.',
+    },
+    {
+        name: 'selectable',
+        type: 'boolean',
+        default: 'true',
+        description: 'Whether nodes can be selected.',
+    },
+    {
+        name: 'selectedKey',
+        type: 'string | null',
+        description: 'Controlled selected node ID.',
+    },
+    {
+        name: 'defaultSelectedKey',
+        type: 'string | null',
+        description: 'Uncontrolled default selected node ID.',
+    },
+    {
+        name: 'onSelect',
+        type: '(key: string, node: TreeNodeData) => void',
+        description: 'Called when a node is selected.',
+    },
+    {
+        name: 'edgeStyle',
+        type: '"solid" | "dashed" | "dotted" | "none"',
+        default: '"none"',
+        description: 'Style of guide lines connecting parent and child nodes.',
+    },
+    {
+        name: 'indentSize',
+        type: 'number',
+        default: '20',
+        description: 'Indentation per level in pixels.',
+    },
+    {
+        name: 'expandOnClick',
+        type: 'boolean',
+        default: 'true',
+        description: 'If true, clicking the whole row toggles expansion. If false, only the icon does.',
+    },
+    {
+        name: 'expandIcon',
+        type: '(props: ExpandIconRenderProps) => React.ReactNode',
+        description: 'Custom expand/collapse icon renderer. Return null to hide it.',
+    },
+];
+
+const treeNodeDataProps: PropDefinition[] = [
+    {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description: 'Unique identifier for the node.',
+    },
+    {
+        name: 'label',
+        type: 'React.ReactNode',
+        required: true,
+        description: 'Label displayed in the node row.',
+    },
+    {
+        name: 'icon',
+        type: 'React.ReactNode',
+        description: 'Optional icon rendered before the label.',
+    },
+    {
+        name: 'badge',
+        type: 'React.ReactNode',
+        description: 'Optional content rendered on the right (badges, actions, etc.).',
+    },
+    {
+        name: 'children',
+        type: 'TreeNodeData[]',
+        description: 'Child nodes.',
+    },
+    {
+        name: 'disabled',
+        type: 'boolean',
+        default: 'false',
+        description: 'Whether the node is disabled.',
+    },
+];
+
+const fileTreeNodes: TreeNodeData[] = [
+    {
+        id: 'src',
+        label: 'src',
+        icon: <Icon name="folder" />,
+        children: [
+            {
+                id: 'src/components',
+                label: 'components',
+                icon: <Icon name="folder" />,
+                children: [
+                    { id: 'src/components/Button.tsx', label: 'Button.tsx', icon: <Icon name="file" /> },
+                    { id: 'src/components/Input.tsx', label: 'Input.tsx', icon: <Icon name="file" /> },
+                    { id: 'src/components/Modal.tsx', label: 'Modal.tsx', icon: <Icon name="file" /> },
+                ],
+            },
+            {
+                id: 'src/styles',
+                label: 'styles',
+                icon: <Icon name="folder" />,
+                children: [
+                    { id: 'src/styles/tokens.ts', label: 'tokens.ts', icon: <Icon name="file" /> },
+                    { id: 'src/styles/global.css', label: 'global.css', icon: <Icon name="file" /> },
+                ],
+            },
+            { id: 'src/index.ts', label: 'index.ts', icon: <Icon name="file" /> },
+        ],
+    },
+    { id: 'package.json', label: 'package.json', icon: <Icon name="file" /> },
+    { id: 'README.md', label: 'README.md', icon: <Icon name="file" /> },
+];
+
+function BasicTreeExample() {
+    return (
+        <div style={{ width: '100%', maxWidth: 360 }}>
+            <Tree nodes={fileTreeNodes} defaultExpandedKeys={['src', 'src/components']} />
+        </div>
+    );
+}
+
+function EdgeStyleExample() {
+    return (
+        <div
+            style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+                gap: 'var(--bk-gap-lg)',
+                width: '100%',
+            }}
+        >
+            <div>
+                <Text size="sm" color="muted">solid</Text>
+                <Tree nodes={fileTreeNodes} defaultExpandedKeys={['src']} edgeStyle="solid" />
+            </div>
+            <div>
+                <Text size="sm" color="muted">dashed</Text>
+                <Tree nodes={fileTreeNodes} defaultExpandedKeys={['src']} edgeStyle="dashed" />
+            </div>
+            <div>
+                <Text size="sm" color="muted">dotted</Text>
+                <Tree nodes={fileTreeNodes} defaultExpandedKeys={['src']} edgeStyle="dotted" />
+            </div>
+            <div>
+                <Text size="sm" color="muted">none (default)</Text>
+                <Tree nodes={fileTreeNodes} defaultExpandedKeys={['src']} edgeStyle="none" />
+            </div>
+        </div>
+    );
+}
+
+const issueTreeNodes: TreeNodeData[] = [
+    {
+        id: 'errors',
+        label: 'Errors',
+        icon: <Icon name="error" color="var(--bk-color-danger)" />,
+        badge: <Badge variant="error" size="sm">3</Badge>,
+        children: [
+            { id: 'err-1', label: 'Cannot read property of undefined', icon: <Icon name="bug" /> },
+            { id: 'err-2', label: 'Network request failed', icon: <Icon name="bug" /> },
+            { id: 'err-3', label: 'Module not found', icon: <Icon name="bug" /> },
+        ],
+    },
+    {
+        id: 'warnings',
+        label: 'Warnings',
+        icon: <Icon name="warning" color="var(--bk-color-warning)" />,
+        badge: <Badge variant="warning" size="sm">2</Badge>,
+        children: [
+            { id: 'warn-1', label: 'Deprecated API usage', icon: <Icon name="alert" /> },
+            { id: 'warn-2', label: 'Missing dependency', icon: <Icon name="alert" /> },
+        ],
+    },
+    {
+        id: 'info',
+        label: 'Info',
+        icon: <Icon name="info" color="var(--bk-color-info)" />,
+        badge: <Badge variant="info" size="sm">5</Badge>,
+        children: [],
+    },
+    {
+        id: 'legacy',
+        label: 'Legacy (read-only)',
+        icon: <Icon name="archive" />,
+        disabled: true,
+    },
+];
+
+function BadgesExample() {
+    return (
+        <div style={{ width: '100%', maxWidth: 420 }}>
+            <Tree nodes={issueTreeNodes} defaultExpandedKeys={['errors', 'warnings']} />
+        </div>
+    );
+}
+
+function ControlledExample() {
+    const [expanded, setExpanded] = useState<string[]>(['src']);
+    const [selected, setSelected] = useState<string | null>('src/index.ts');
+
+    return (
+        <div style={{ width: '100%', maxWidth: 420 }}>
+            <div style={{ marginBottom: 'var(--bk-spacing-3)' }}>
+                <Text size="sm" color="muted">Selected: </Text>
+                <Text size="sm" weight="semibold">{selected ?? '(none)'}</Text>
+            </div>
+            <Tree
+                nodes={fileTreeNodes}
+                expandedKeys={expanded}
+                onExpandChange={setExpanded}
+                selectedKey={selected}
+                onSelect={(key) => setSelected(key)}
+            />
+        </div>
+    );
+}
+
+function CustomExpandIconExample() {
+    return (
+        <div style={{ width: '100%', maxWidth: 360 }}>
+            <Tree
+                nodes={fileTreeNodes}
+                defaultExpandedKeys={['src']}
+                expandIcon={({ expanded, hasChildren }) =>
+                    hasChildren ? (
+                        <Icon name={expanded ? 'triangle-down' : 'triangle-right'} />
+                    ) : null
+                }
+            />
+        </div>
+    );
+}
+
+// ─── File-manager example (double-click rename + context menu) ───────────────
+
+interface FsNode {
+    id: string;
+    name: string;
+    kind: 'file' | 'folder';
+    children?: FsNode[];
+}
+
+const initialFileTree: FsNode[] = [
+    {
+        id: 'src',
+        name: 'src',
+        kind: 'folder',
+        children: [
+            { id: 'src/index.ts', name: 'index.ts', kind: 'file' },
+            { id: 'src/App.tsx', name: 'App.tsx', kind: 'file' },
+        ],
+    },
+    {
+        id: 'public',
+        name: 'public',
+        kind: 'folder',
+        children: [{ id: 'public/favicon.ico', name: 'favicon.ico', kind: 'file' }],
+    },
+    { id: 'package.json', name: 'package.json', kind: 'file' },
+];
+
+function findFsNode(nodes: FsNode[], id: string): FsNode | undefined {
+    for (const n of nodes) {
+        if (n.id === id) return n;
+        if (n.children) {
+            const found = findFsNode(n.children, id);
+            if (found) return found;
+        }
+    }
+    return undefined;
+}
+
+function renameFsNode(nodes: FsNode[], id: string, name: string): FsNode[] {
+    return nodes.map((n) => {
+        if (n.id === id) return { ...n, name };
+        if (n.children) return { ...n, children: renameFsNode(n.children, id, name) };
+        return n;
+    });
+}
+
+function insertFsChild(nodes: FsNode[], parentId: string, child: FsNode): FsNode[] {
+    return nodes.map((n) => {
+        if (n.id === parentId) return { ...n, children: [...(n.children ?? []), child] };
+        if (n.children) return { ...n, children: insertFsChild(n.children, parentId, child) };
+        return n;
+    });
+}
+
+function removeFsNode(nodes: FsNode[], id: string): FsNode[] {
+    return nodes
+        .filter((n) => n.id !== id)
+        .map((n) => (n.children ? { ...n, children: removeFsNode(n.children, id) } : n));
+}
+
+function FileManagerExample() {
+    const [tree, setTree] = useState<FsNode[]>(initialFileTree);
+    const [expanded, setExpanded] = useState<string[]>(['src']);
+    const [renamingId, setRenamingId] = useState<string | null>(null);
+    const [contextNode, setContextNode] = useState<FsNode | null>(null);
+    const idCounter = useRef(0);
+
+    const commitRename = (id: string, value: string) => {
+        const name = value.trim();
+        if (name) setTree((t) => renameFsNode(t, id, name));
+        setRenamingId(null);
+    };
+
+    // Tree exposes no per-node event props by design — resolve the row
+    // from the data-tree-node-id attribute that every row renders.
+    const nodeFromEvent = (e: MouseEvent): FsNode | null => {
+        const el = (e.target as HTMLElement).closest('[data-tree-node-id]');
+        const id = el?.getAttribute('data-tree-node-id');
+        return id ? (findFsNode(tree, id) ?? null) : null;
+    };
+
+    const addChild = (parentId: string, kind: 'file' | 'folder') => {
+        const id = 'node-' + ++idCounter.current;
+        const child: FsNode =
+            kind === 'folder'
+                ? { id, name: 'new-folder', kind, children: [] }
+                : { id, name: 'new-file.ts', kind };
+        setTree((t) => insertFsChild(t, parentId, child));
+        setExpanded((e) => (e.includes(parentId) ? e : [...e, parentId]));
+    };
+
+    // Map the file-system model to Tree nodes. The row being renamed
+    // swaps its label for an inline Input.
+    const toTreeNodes = (nodes: FsNode[]): TreeNodeData[] =>
+        nodes.map((n) => ({
+            id: n.id,
+            icon: <Icon name={n.kind === 'folder' ? 'folder' : 'file'} />,
+            label:
+                n.id === renamingId ? (
+                    <Input
+                        size="xs"
+                        autoFocus
+                        defaultValue={n.name}
+                        onFocus={(e) => e.currentTarget.select()}
+                        onClick={(e) => e.stopPropagation()}
+                        onDoubleClick={(e) => e.stopPropagation()}
+                        onKeyDown={(e) => {
+                            e.stopPropagation();
+                            if (e.key === 'Enter') commitRename(n.id, e.currentTarget.value);
+                            if (e.key === 'Escape') setRenamingId(null);
+                        }}
+                        onBlur={(e) => commitRename(n.id, e.currentTarget.value)}
+                    />
+                ) : (
+                    n.name
+                ),
+            children: n.children ? toTreeNodes(n.children) : undefined,
+        }));
+
+    return (
+        <div style={{ width: '100%', maxWidth: 420 }}>
+            <Text size="sm" color="muted" block style={{ marginBottom: 'var(--bk-spacing-3)' }}>
+                Double-click a row to rename it. Right-click for actions.
+            </Text>
+            <ContextMenu
+                menu={
+                    contextNode?.kind === 'folder' ? (
+                        <>
+                            <MenuItem
+                                icon={<Icon name="new-folder" />}
+                                onClick={() => addChild(contextNode.id, 'folder')}
+                            >
+                                New Folder
+                            </MenuItem>
+                            <MenuItem
+                                icon={<Icon name="new-file" />}
+                                onClick={() => addChild(contextNode.id, 'file')}
+                            >
+                                New File
+                            </MenuItem>
+                            <MenuDivider />
+                            <MenuItem
+                                icon={<Icon name="edit" />}
+                                onClick={() => setRenamingId(contextNode.id)}
+                            >
+                                Rename
+                            </MenuItem>
+                        </>
+                    ) : contextNode ? (
+                        <>
+                            <MenuItem
+                                icon={<Icon name="edit" />}
+                                onClick={() => setRenamingId(contextNode.id)}
+                            >
+                                Rename
+                            </MenuItem>
+                            <MenuDivider />
+                            <MenuItem
+                                icon={<Icon name="trash" />}
+                                onClick={() => setTree((t) => removeFsNode(t, contextNode.id))}
+                            >
+                                Delete
+                            </MenuItem>
+                        </>
+                    ) : null
+                }
+            >
+                <Tree
+                    nodes={toTreeNodes(tree)}
+                    edgeStyle="solid"
+                    expandedKeys={expanded}
+                    onExpandChange={setExpanded}
+                    onDoubleClick={(e) => {
+                        const node = nodeFromEvent(e);
+                        if (node) setRenamingId(node.id);
+                    }}
+                    onContextMenu={(e) => {
+                        const node = nodeFromEvent(e);
+                        setContextNode(node);
+                        // Right-click outside any row: suppress both menus.
+                        if (!node) {
+                            e.preventDefault();
+                            e.stopPropagation();
+                        }
+                    }}
+                />
+            </ContextMenu>
+        </div>
+    );
+}
+
+export default function TreePage() {
+    return (
+        <PageLayout
+            title="Tree"
+            description="A hierarchical tree view for file explorers, settings hierarchies, and nested navigation. Supports expand/collapse, single selection, keyboard navigation, guide edges, icons, and badges."
+        >
+            <Showcase
+                title="Basic Usage"
+                description="Provide a nested array of nodes. Each node needs a unique id and a label."
+                preview={<BasicTreeExample />}
+                code={`import { Tree } from 'baukasten-ui/extra';
+import type { TreeNodeData } from 'baukasten-ui/extra';
+import { Icon } from 'baukasten-ui/core';
+
+const nodes: TreeNodeData[] = [
+  {
+    id: 'src',
+    label: 'src',
+    icon: <Icon name="folder" />,
+    children: [
+      { id: 'src/index.ts', label: 'index.ts', icon: <Icon name="file" /> },
+      { id: 'src/App.tsx', label: 'App.tsx', icon: <Icon name="file" /> },
+    ],
+  },
+  { id: 'package.json', label: 'package.json', icon: <Icon name="file" /> },
+];
+
+<Tree nodes={nodes} defaultExpandedKeys={['src']} />`}
+            />
+
+            <Showcase
+                title="Edge Styles"
+                description="Use edgeStyle to draw guide lines between parents and children. Useful for deep hierarchies."
+                preview={<EdgeStyleExample />}
+                code={`<Tree nodes={nodes} edgeStyle="solid" />
+<Tree nodes={nodes} edgeStyle="dashed" />
+<Tree nodes={nodes} edgeStyle="dotted" />
+<Tree nodes={nodes} edgeStyle="none" />  // default`}
+            />
+
+            <Showcase
+                title="Badges and Disabled Nodes"
+                description="Add right-side content via the badge field, and prevent interaction with disabled."
+                preview={<BadgesExample />}
+                code={`const nodes: TreeNodeData[] = [
+  {
+    id: 'errors',
+    label: 'Errors',
+    icon: <Icon name="error" />,
+    badge: <Badge variant="error" size="sm">3</Badge>,
+    children: [
+      { id: 'err-1', label: 'Cannot read property of undefined' },
+    ],
+  },
+  {
+    id: 'legacy',
+    label: 'Legacy (read-only)',
+    icon: <Icon name="archive" />,
+    disabled: true,
+  },
+];
+
+<Tree nodes={nodes} defaultExpandedKeys={['errors']} />`}
+            />
+
+            <Showcase
+                title="Controlled Expansion and Selection"
+                description="Pass expandedKeys + onExpandChange and selectedKey + onSelect to drive the tree from your own state."
+                preview={<ControlledExample />}
+                code={`const [expanded, setExpanded] = useState<string[]>(['src']);
+const [selected, setSelected] = useState<string | null>(null);
+
+<Tree
+  nodes={nodes}
+  expandedKeys={expanded}
+  onExpandChange={setExpanded}
+  selectedKey={selected}
+  onSelect={(key) => setSelected(key)}
+/>`}
+            />
+
+            <Showcase
+                title="Custom Expand Icon"
+                description="Replace the default chevron with a custom renderer. Return null to hide the icon for leaf nodes."
+                preview={<CustomExpandIconExample />}
+                code={`<Tree
+  nodes={nodes}
+  expandIcon={({ expanded, hasChildren }) =>
+    hasChildren ? (
+      <Icon name={expanded ? 'triangle-down' : 'triangle-right'} />
+    ) : null
+  }
+/>`}
+            />
+
+            <Showcase
+                title="File Manager: Rename & Context Menu"
+                description="Double-click a row to rename it inline; right-click for context-aware actions — New Folder / New File on folders, Delete on files. Tree has no per-node event handlers by design: onDoubleClick and onContextMenu live on the Tree container (it forwards standard HTML attributes), and the clicked row is resolved from the data-tree-node-id attribute every row renders."
+                preview={<FileManagerExample />}
+                code={`import { useRef, useState, type MouseEvent } from 'react';
+import { Icon, Input, Text } from 'baukasten-ui/core';
+import { Tree, ContextMenu, MenuItem, MenuDivider } from 'baukasten-ui/extra';
+import type { TreeNodeData } from 'baukasten-ui/extra';
+
+interface FsNode {
+  id: string;
+  name: string;
+  kind: 'file' | 'folder';
+  children?: FsNode[];
+}
+
+// Immutable recursive helpers over the file-system model
+function findFsNode(nodes: FsNode[], id: string): FsNode | undefined {
+  for (const n of nodes) {
+    if (n.id === id) return n;
+    if (n.children) {
+      const found = findFsNode(n.children, id);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+function renameFsNode(nodes: FsNode[], id: string, name: string): FsNode[] {
+  return nodes.map((n) => {
+    if (n.id === id) return { ...n, name };
+    if (n.children) return { ...n, children: renameFsNode(n.children, id, name) };
+    return n;
+  });
+}
+
+function insertFsChild(nodes: FsNode[], parentId: string, child: FsNode): FsNode[] {
+  return nodes.map((n) => {
+    if (n.id === parentId) return { ...n, children: [...(n.children ?? []), child] };
+    if (n.children) return { ...n, children: insertFsChild(n.children, parentId, child) };
+    return n;
+  });
+}
+
+function removeFsNode(nodes: FsNode[], id: string): FsNode[] {
+  return nodes
+    .filter((n) => n.id !== id)
+    .map((n) => (n.children ? { ...n, children: removeFsNode(n.children, id) } : n));
+}
+
+function FileManager({ initialTree }: { initialTree: FsNode[] }) {
+  const [tree, setTree] = useState<FsNode[]>(initialTree);
+  const [expanded, setExpanded] = useState<string[]>(['src']);
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [contextNode, setContextNode] = useState<FsNode | null>(null);
+  const idCounter = useRef(0);
+
+  const commitRename = (id: string, value: string) => {
+    const name = value.trim();
+    if (name) setTree((t) => renameFsNode(t, id, name));
+    setRenamingId(null);
+  };
+
+  // Tree exposes no per-node event props by design — resolve the row
+  // from the data-tree-node-id attribute that every row renders.
+  const nodeFromEvent = (e: MouseEvent): FsNode | null => {
+    const el = (e.target as HTMLElement).closest('[data-tree-node-id]');
+    const id = el?.getAttribute('data-tree-node-id');
+    return id ? (findFsNode(tree, id) ?? null) : null;
+  };
+
+  const addChild = (parentId: string, kind: 'file' | 'folder') => {
+    const id = 'node-' + ++idCounter.current;
+    const child: FsNode =
+      kind === 'folder'
+        ? { id, name: 'new-folder', kind, children: [] }
+        : { id, name: 'new-file.ts', kind };
+    setTree((t) => insertFsChild(t, parentId, child));
+    setExpanded((e) => (e.includes(parentId) ? e : [...e, parentId]));
+  };
+
+  // Map the file-system model to Tree nodes. The row being renamed
+  // swaps its label for an inline Input.
+  const toTreeNodes = (nodes: FsNode[]): TreeNodeData[] =>
+    nodes.map((n) => ({
+      id: n.id,
+      icon: <Icon name={n.kind === 'folder' ? 'folder' : 'file'} />,
+      label:
+        n.id === renamingId ? (
+          <Input
+            size="xs"
+            autoFocus
+            defaultValue={n.name}
+            onFocus={(e) => e.currentTarget.select()}
+            onClick={(e) => e.stopPropagation()}
+            onDoubleClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => {
+              e.stopPropagation();
+              if (e.key === 'Enter') commitRename(n.id, e.currentTarget.value);
+              if (e.key === 'Escape') setRenamingId(null);
+            }}
+            onBlur={(e) => commitRename(n.id, e.currentTarget.value)}
+          />
+        ) : (
+          n.name
+        ),
+      children: n.children ? toTreeNodes(n.children) : undefined,
+    }));
+
+  return (
+    <ContextMenu
+      menu={
+        contextNode?.kind === 'folder' ? (
+          <>
+            <MenuItem
+              icon={<Icon name="new-folder" />}
+              onClick={() => addChild(contextNode.id, 'folder')}
+            >
+              New Folder
+            </MenuItem>
+            <MenuItem
+              icon={<Icon name="new-file" />}
+              onClick={() => addChild(contextNode.id, 'file')}
+            >
+              New File
+            </MenuItem>
+            <MenuDivider />
+            <MenuItem
+              icon={<Icon name="edit" />}
+              onClick={() => setRenamingId(contextNode.id)}
+            >
+              Rename
+            </MenuItem>
+          </>
+        ) : contextNode ? (
+          <>
+            <MenuItem
+              icon={<Icon name="edit" />}
+              onClick={() => setRenamingId(contextNode.id)}
+            >
+              Rename
+            </MenuItem>
+            <MenuDivider />
+            <MenuItem
+              icon={<Icon name="trash" />}
+              onClick={() => setTree((t) => removeFsNode(t, contextNode.id))}
+            >
+              Delete
+            </MenuItem>
+          </>
+        ) : null
+      }
+    >
+      <Tree
+        nodes={toTreeNodes(tree)}
+        edgeStyle="solid"
+        expandedKeys={expanded}
+        onExpandChange={setExpanded}
+        onDoubleClick={(e) => {
+          const node = nodeFromEvent(e);
+          if (node) setRenamingId(node.id);
+        }}
+        onContextMenu={(e) => {
+          const node = nodeFromEvent(e);
+          setContextNode(node);
+          // Right-click outside any row: suppress both menus.
+          if (!node) {
+            e.preventDefault();
+            e.stopPropagation();
+          }
+        }}
+      />
+    </ContextMenu>
+  );
+}`}
+                props={[
+                    ...treeProps,
+                    { name: '---', type: '---', description: 'TreeNodeData fields:' },
+                    ...treeNodeDataProps,
+                ]}
+            />
+        </PageLayout>
+    );
+}

--- a/packages/website/src/app/components/tree/page.tsx
+++ b/packages/website/src/app/components/tree/page.tsx
@@ -73,7 +73,8 @@ const treeProps: PropDefinition[] = [
         name: 'expandOnClick',
         type: 'boolean',
         default: 'true',
-        description: 'If true, clicking the whole row toggles expansion. If false, only the icon does.',
+        description:
+            'If true, clicking the whole row toggles expansion. If false, only the icon does.',
     },
     {
         name: 'expandIcon',
@@ -129,9 +130,21 @@ const fileTreeNodes: TreeNodeData[] = [
                 label: 'components',
                 icon: <Icon name="folder" />,
                 children: [
-                    { id: 'src/components/Button.tsx', label: 'Button.tsx', icon: <Icon name="file" /> },
-                    { id: 'src/components/Input.tsx', label: 'Input.tsx', icon: <Icon name="file" /> },
-                    { id: 'src/components/Modal.tsx', label: 'Modal.tsx', icon: <Icon name="file" /> },
+                    {
+                        id: 'src/components/Button.tsx',
+                        label: 'Button.tsx',
+                        icon: <Icon name="file" />,
+                    },
+                    {
+                        id: 'src/components/Input.tsx',
+                        label: 'Input.tsx',
+                        icon: <Icon name="file" />,
+                    },
+                    {
+                        id: 'src/components/Modal.tsx',
+                        label: 'Modal.tsx',
+                        icon: <Icon name="file" />,
+                    },
                 ],
             },
             {
@@ -140,7 +153,11 @@ const fileTreeNodes: TreeNodeData[] = [
                 icon: <Icon name="folder" />,
                 children: [
                     { id: 'src/styles/tokens.ts', label: 'tokens.ts', icon: <Icon name="file" /> },
-                    { id: 'src/styles/global.css', label: 'global.css', icon: <Icon name="file" /> },
+                    {
+                        id: 'src/styles/global.css',
+                        label: 'global.css',
+                        icon: <Icon name="file" />,
+                    },
                 ],
             },
             { id: 'src/index.ts', label: 'index.ts', icon: <Icon name="file" /> },
@@ -169,19 +186,27 @@ function EdgeStyleExample() {
             }}
         >
             <div>
-                <Text size="sm" color="muted">solid</Text>
+                <Text size="sm" color="muted">
+                    solid
+                </Text>
                 <Tree nodes={fileTreeNodes} defaultExpandedKeys={['src']} edgeStyle="solid" />
             </div>
             <div>
-                <Text size="sm" color="muted">dashed</Text>
+                <Text size="sm" color="muted">
+                    dashed
+                </Text>
                 <Tree nodes={fileTreeNodes} defaultExpandedKeys={['src']} edgeStyle="dashed" />
             </div>
             <div>
-                <Text size="sm" color="muted">dotted</Text>
+                <Text size="sm" color="muted">
+                    dotted
+                </Text>
                 <Tree nodes={fileTreeNodes} defaultExpandedKeys={['src']} edgeStyle="dotted" />
             </div>
             <div>
-                <Text size="sm" color="muted">none (default)</Text>
+                <Text size="sm" color="muted">
+                    none (default)
+                </Text>
                 <Tree nodes={fileTreeNodes} defaultExpandedKeys={['src']} edgeStyle="none" />
             </div>
         </div>
@@ -193,7 +218,11 @@ const issueTreeNodes: TreeNodeData[] = [
         id: 'errors',
         label: 'Errors',
         icon: <Icon name="error" color="var(--bk-color-danger)" />,
-        badge: <Badge variant="error" size="sm">3</Badge>,
+        badge: (
+            <Badge variant="error" size="sm">
+                3
+            </Badge>
+        ),
         children: [
             { id: 'err-1', label: 'Cannot read property of undefined', icon: <Icon name="bug" /> },
             { id: 'err-2', label: 'Network request failed', icon: <Icon name="bug" /> },
@@ -204,7 +233,11 @@ const issueTreeNodes: TreeNodeData[] = [
         id: 'warnings',
         label: 'Warnings',
         icon: <Icon name="warning" color="var(--bk-color-warning)" />,
-        badge: <Badge variant="warning" size="sm">2</Badge>,
+        badge: (
+            <Badge variant="warning" size="sm">
+                2
+            </Badge>
+        ),
         children: [
             { id: 'warn-1', label: 'Deprecated API usage', icon: <Icon name="alert" /> },
             { id: 'warn-2', label: 'Missing dependency', icon: <Icon name="alert" /> },
@@ -214,7 +247,11 @@ const issueTreeNodes: TreeNodeData[] = [
         id: 'info',
         label: 'Info',
         icon: <Icon name="info" color="var(--bk-color-info)" />,
-        badge: <Badge variant="info" size="sm">5</Badge>,
+        badge: (
+            <Badge variant="info" size="sm">
+                5
+            </Badge>
+        ),
         children: [],
     },
     {
@@ -240,8 +277,12 @@ function ControlledExample() {
     return (
         <div style={{ width: '100%', maxWidth: 420 }}>
             <div style={{ marginBottom: 'var(--bk-spacing-3)' }}>
-                <Text size="sm" color="muted">Selected: </Text>
-                <Text size="sm" weight="semibold">{selected ?? '(none)'}</Text>
+                <Text size="sm" color="muted">
+                    Selected:{' '}
+                </Text>
+                <Text size="sm" weight="semibold">
+                    {selected ?? '(none)'}
+                </Text>
             </div>
             <Tree
                 nodes={fileTreeNodes}

--- a/packages/website/src/app/page.tsx
+++ b/packages/website/src/app/page.tsx
@@ -242,7 +242,7 @@ export default function Home() {
                                 }}
                             >
                                 <Icon
-                                    name="paintcan"
+                                    name="robot"
                                     style={{
                                         fontSize: '24px',
                                         color: 'var(--vscode-button-background)',
@@ -255,7 +255,7 @@ export default function Home() {
                                         color: 'var(--vscode-foreground)',
                                     }}
                                 >
-                                    Application UI Focus
+                                    AI Ready
                                 </Text>
                             </div>
                             <Text
@@ -265,7 +265,8 @@ export default function Home() {
                                     lineHeight: 1.6,
                                 }}
                             >
-                                Built for professional, data-intensive Desktop & Web Applications
+                                Get our Agent Skill to speed up Agentic UI Development & achieve
+                                faster design iterations
                             </Text>
                         </div>
                     </div>
@@ -685,6 +686,234 @@ export default function Home() {
                             </Paragraph>
                         </div>
                     ))}
+                </div>
+            </div>
+
+            {/* AI-Ready */}
+            <div style={{ marginBottom: 'var(--bk-spacing-12)' }}>
+                <div style={{ textAlign: 'center', marginBottom: 'var(--bk-spacing-10)' }}>
+                    <Heading
+                        level={2}
+                        style={{
+                            marginBottom: 'var(--bk-spacing-4)',
+                            fontSize: 'calc(var(--vscode-font-size) * 2)',
+                        }}
+                    >
+                        AI-Ready
+                        <Icon
+                            name="sparkle"
+                            style={{
+                                fontSize: 'calc(var(--vscode-font-size) * 1.4)',
+                                color: 'var(--vscode-button-background)',
+                                marginLeft: 'var(--bk-spacing-2)',
+                                verticalAlign: 'middle',
+                            }}
+                        />
+                        <Badge
+                            variant="info"
+                            size="sm"
+                            style={{
+                                marginLeft: 'var(--bk-spacing-2)',
+                                verticalAlign: 'middle',
+                            }}
+                        >
+                            New
+                        </Badge>
+                    </Heading>
+                    <Paragraph
+                        style={{
+                            color: 'var(--vscode-descriptionForeground)',
+                            fontSize: 'calc(var(--vscode-font-size) * 1.1)',
+                            maxWidth: '720px',
+                            margin: '0 auto',
+                        }}
+                    >
+                        Baukasten ships with an agent skill so coding assistants generate accurate
+                        Baukasten UI out of the box — correct imports, real props, real defaults. No
+                        more invented APIs.
+                    </Paragraph>
+                </div>
+
+                <div
+                    style={{
+                        display: 'grid',
+                        gridTemplateColumns: 'repeat(auto-fit, minmax(340px, 1fr))',
+                        gap: 'var(--bk-spacing-6)',
+                        alignItems: 'stretch',
+                    }}
+                >
+                    <div
+                        style={{
+                            backgroundColor: 'var(--vscode-editor-background)',
+                            border: '1px solid var(--vscode-panel-border)',
+                            borderRadius: 'var(--bk-radius-md)',
+                            padding: 'var(--bk-spacing-7)',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: 'var(--bk-spacing-4)',
+                        }}
+                    >
+                        <div
+                            style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 'var(--bk-gap-md)',
+                            }}
+                        >
+                            <Icon
+                                name="hubot"
+                                style={{
+                                    fontSize: '32px',
+                                    color: 'var(--vscode-button-background)',
+                                }}
+                            />
+                            <Heading
+                                level={3}
+                                style={{
+                                    margin: 0,
+                                    fontSize: 'calc(var(--vscode-font-size) * 1.2)',
+                                    fontWeight: 600,
+                                }}
+                            >
+                                Built-in Agent skill
+                            </Heading>
+                        </div>
+                        <Paragraph
+                            style={{
+                                color: 'var(--vscode-descriptionForeground)',
+                                lineHeight: 1.7,
+                                margin: 0,
+                                fontSize: 'calc(var(--vscode-font-size) * 0.95)',
+                            }}
+                        >
+                            The <code>write-baukasten</code> skill loads automatically whenever your
+                            coding agent sees an import from <code>baukasten-ui</code>. It carries a
+                            full reference for every component — props, defaults, variants,
+                            patterns, and platform-specific setup — audited against the source.
+                        </Paragraph>
+                        <ul
+                            style={{
+                                listStyle: 'none',
+                                padding: 0,
+                                margin: 0,
+                                display: 'flex',
+                                flexDirection: 'column',
+                                gap: 'var(--bk-spacing-2)',
+                            }}
+                        >
+                            {[
+                                'Accurate, source-audited prop tables',
+                                'Knows the core / extra split and CSS setup',
+                                'Steers the assistant away from VSCode-only hacks',
+                                'No setup — just install baukasten-ui',
+                            ].map((line) => (
+                                <li
+                                    key={line}
+                                    style={{
+                                        display: 'flex',
+                                        alignItems: 'flex-start',
+                                        gap: 'var(--bk-gap-sm)',
+                                        color: 'var(--vscode-foreground)',
+                                        fontSize: 'calc(var(--vscode-font-size) * 0.95)',
+                                    }}
+                                >
+                                    <Icon
+                                        name="check"
+                                        style={{
+                                            fontSize: '16px',
+                                            marginTop: '3px',
+                                            color: 'var(--vscode-button-background)',
+                                            flexShrink: 0,
+                                        }}
+                                    />
+                                    <Text>{line}</Text>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+
+                    <div
+                        style={{
+                            backgroundColor:
+                                'var(--vscode-terminal-background, var(--vscode-editor-background))',
+                            border: '1px solid var(--vscode-panel-border)',
+                            borderRadius: 'var(--bk-radius-md)',
+                            overflow: 'hidden',
+                            display: 'flex',
+                            flexDirection: 'column',
+                        }}
+                    >
+                        <div
+                            style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 'var(--bk-gap-sm)',
+                                padding: 'var(--bk-padding-sm) var(--bk-padding-md)',
+                                backgroundColor:
+                                    'var(--vscode-titleBar-activeBackground, var(--vscode-sideBar-background))',
+                                borderBottom: '1px solid var(--vscode-panel-border)',
+                            }}
+                        >
+                            <span
+                                style={{
+                                    width: 10,
+                                    height: 10,
+                                    borderRadius: '50%',
+                                    backgroundColor: '#ff5f57',
+                                }}
+                            />
+                            <span
+                                style={{
+                                    width: 10,
+                                    height: 10,
+                                    borderRadius: '50%',
+                                    backgroundColor: '#febc2e',
+                                }}
+                            />
+                            <span
+                                style={{
+                                    width: 10,
+                                    height: 10,
+                                    borderRadius: '50%',
+                                    backgroundColor: '#28c840',
+                                }}
+                            />
+                            <Text
+                                size="xs"
+                                color="muted"
+                                style={{ marginLeft: 'var(--bk-spacing-2)' }}
+                            >
+                                claude — baukasten
+                            </Text>
+                        </div>
+                        <pre
+                            style={{
+                                margin: 0,
+                                padding: 'var(--bk-padding-md)',
+                                fontFamily:
+                                    'var(--vscode-editor-font-family, ui-monospace, "SF Mono", Menlo, Consolas, monospace)',
+                                fontSize: '12px',
+                                lineHeight: 1.55,
+                                color: 'var(--vscode-terminal-foreground, var(--vscode-foreground))',
+                                overflowX: 'auto',
+                                whiteSpace: 'pre',
+                                flex: 1,
+                            }}
+                        >
+                            {`❯ Using baukasten, I would like to create a domain
+  specific application, that will run as a VSCode
+  extension.
+  ⎿  ⧉ Selected 1 lines from package.json in Visual Studio Code
+
+⏺ Happy to help scaffold that. Before I start, let
+  me read baukasten skill.
+
+⏺ Skill(write-baukasten)
+  ⎿  Successfully loaded skill
+
+⏺ What domain/purpose should this VSCode extension serve?`}
+                        </pre>
+                    </div>
                 </div>
             </div>
         </PageLayout>

--- a/packages/website/src/components/Navigation.tsx
+++ b/packages/website/src/components/Navigation.tsx
@@ -47,6 +47,7 @@ const extraComponents = [
     { name: 'SplitPane', path: '/components/splitpane' },
     { name: 'StatusBar', path: '/components/statusbar' },
     { name: 'Tabs', path: '/components/tabs' },
+    { name: 'Tree', path: '/components/tree' },
 ];
 
 const foundations = [


### PR DESCRIPTION
Add a new Tree component with support for hierarchical node structures, expandable/collapsible nodes, selection, keyboard navigation, and customizable edge guide lines. Includes comprehensive Storybook stories and website documentation.

The Tree component provides:
- Recursive node rendering with depth-based indentation
- Controlled and uncontrolled expansion/selection states
- Customizable edge styles (solid, dashed, dotted, none)
- Full ARIA support for accessibility
- Keyboard navigation (arrow keys, Enter, Space)
- Custom expand icon rendering
- Size variants (xs, sm, md, lg, xl)
- Integration with other Baukasten components (Icon, Badge, Tooltip, etc.)

Also fix website:start script to use dev instead of start command, and update homepage with AI-Ready section.

<!-- Describe your changes above this line -->

---

## Risk level:

- [x] Low risk (docs, tests, minor fixes)
- [ ] Medium risk (above average work, refactors)
- [ ] High risk (infra, critical changes)
