### PR TITLE
Trusted Publishing

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -2,15 +2,25 @@
 name: Build website and storybook, publish to GitHub Pages
 
 on:
-    # Event for the workflow to run on
     push:
         branches:
             - 'main'
+        # only publish when package.json files change, to sync with the publish workflow
+        paths:
+            - 'package.json'
+            - '**/package.json'
+    # Allow deploying the site manually, without a version bump
+    workflow_dispatch:
 
 permissions:
     contents: read
     pages: write
     id-token: write
+
+# Pages allows only one deployment at a time; queue instead of failing
+concurrency:
+    group: 'pages'
+    cancel-in-progress: false
 
 # List of jobs
 jobs:
@@ -23,8 +33,6 @@ jobs:
         steps:
             # Manual Checkout
             - uses: actions/checkout@v4
-              with:
-                  fetch-depth: 0
 
             # Set up Node
             - uses: actions/setup-node@v4

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -1,0 +1,61 @@
+name: Publish (next)
+
+# Publishes a "next" snapshot of the public baukasten packages to npm under
+# the `next` dist-tag. Manually triggered only.
+#
+# Mirrors publish.yml (checkout/setup-node pins, npm upgrade, lint/format
+# checks, build, gh-publish-npm with OIDC trusted publishing), but first
+# bumps to a prerelease version via the existing root "prepare-next" script
+# and publishes under the `next` tag instead of `latest`.
+
+on:
+    workflow_dispatch: {}
+
+permissions:
+    contents: read
+    id-token: write # Required for npm OIDC trusted publishing
+
+# Never let this race the regular publish workflow or another next-publish
+concurrency:
+    group: publish
+    cancel-in-progress: false
+
+jobs:
+    publish-next:
+        name: Baukasten Publish (next)
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+            - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+              with:
+                  node-version: '22'
+                  # Required by the publish action for --provenance
+                  registry-url: 'https://registry.npmjs.org'
+
+            - name: Upgrade npm
+              run: npm install -g npm@latest
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Run checks
+              run: npm run lint && npm run format:check
+
+            - name: Build all packages
+              run: npm run build
+
+            - name: Prepare next version
+              # Root script (already on master): bumps each workspace to a
+              # prerelease version via "prepare:next" where present.
+              run: npm run prepare-next
+
+            - name: Publish
+              # Pin the version to a full commit SHA for supply-chain safety
+              uses: TypeFox/gh-publish-npm@7183224bef010236e419a2367208633ff284337a
+              with:
+                  npm-tag: next
+                  # Newline-separated. Only non-private, npm-published packages belong here.
+                  npm-packages: |
+                      packages/baukasten
+                      packages/web-wrapper

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,9 +22,9 @@ jobs:
         name: Baukasten Publish
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
               with:
                   node-version: '20'
                   # Required by the publish action for --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish
+
+permissions:
+    contents: read
+    id-token: write
+
+on:
+    push:
+        branches:
+            - 'main'
+        paths:
+            - '**/package.json'
+
+jobs:
+    publish:
+        name: Baukasten Publish
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '20'
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Build all packages
+              run: npm run build
+
+            - name: Run checks
+              run: npm run lint && npm run format:check
+
+            - name: Publish
+              # Pin the version to a full commit SHA for supply-chain safety
+              uses: TypeFox/gh-publish-npm@7183224bef010236e419a2367208633ff284337a
+              with:
+                  dry-run: ${{ github.event_name == 'pull_request' }}
+                  npm-packages: packages/baukasten,packages/website
+                  ovsx-token: ${{ github.event_name != 'pull_request' && secrets.OVSX_TOKEN || '' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,13 @@ on:
         branches:
             - 'main'
         paths:
+            - 'package.json'
             - '**/package.json'
+
+# Never let two publish runs race each other
+concurrency:
+    group: publish
+    cancel-in-progress: false
 
 jobs:
     publish:
@@ -17,26 +23,31 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-              with:
-                  fetch-depth: 0
 
             - uses: actions/setup-node@v4
               with:
                   node-version: '20'
+                  # Required by the publish action for --provenance
+                  registry-url: 'https://registry.npmjs.org'
+
+            # Node 20 ships npm 10.x; OIDC trusted publishing needs npm >= 11.5.1
+            - name: Upgrade npm
+              run: npm install -g npm@latest
 
             - name: Install dependencies
               run: npm ci
 
-            - name: Build all packages
-              run: npm run build
-
             - name: Run checks
               run: npm run lint && npm run format:check
+
+            - name: Build all packages
+              run: npm run build
 
             - name: Publish
               # Pin the version to a full commit SHA for supply-chain safety
               uses: TypeFox/gh-publish-npm@7183224bef010236e419a2367208633ff284337a
               with:
-                  dry-run: ${{ github.event_name == 'pull_request' }}
-                  npm-packages: packages/baukasten,packages/website
-                  ovsx-token: ${{ github.event_name != 'pull_request' && secrets.OVSX_TOKEN || '' }}
+                  # Newline-separated. Only non-private, npm-published packages belong here.
+                  npm-packages: |
+                      packages/baukasten
+                      packages/web-wrapper


### PR DESCRIPTION
Added the trusted publishing using https://github.com/TypeFox/gh-publish-npm/releases/tag/v0.5.0

---

## Risk level:

- [ ] Low risk (docs, tests, minor fixes)
- [ ] Medium risk (above average work, refactors)
- [x] High risk (infra, critical changes)
